### PR TITLE
Mobile bottom navigation

### DIFF
--- a/apps/web/src/widgets/layout/AppLayout.tsx
+++ b/apps/web/src/widgets/layout/AppLayout.tsx
@@ -2,36 +2,25 @@ import { useState } from 'react'
 import { Box, Drawer, useMediaQuery, useTheme } from '@mui/material'
 import { Outlet } from 'react-router'
 import { Sidebar } from './Sidebar'
+import { MobileNav } from './MobileNav'
 
 export const SIDEBAR_WIDTH = 220
 export const SIDEBAR_COLLAPSED_WIDTH = 64
 
 /**
  * Layout приложения: сайдбар слева + контент справа.
- * Используется как родительский маршрут в роутере — состояние collapsed
- * сохраняется при навигации между страницами.
+ * На мобильном сайдбар заменяется нижней навигацией.
  */
 export const AppLayout = () => {
   const theme = useTheme()
   const isMobile = useMediaQuery(theme.breakpoints.down('md'))
   const [collapsed, setCollapsed] = useState(false)
-  const [mobileOpen, setMobileOpen] = useState(false)
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH
 
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'background.default' }}>
-      {isMobile ? (
-        <Drawer
-          variant="temporary"
-          open={mobileOpen}
-          onClose={() => setMobileOpen(false)}
-          ModalProps={{ keepMounted: true }}
-          sx={{ '& .MuiDrawer-paper': { width: SIDEBAR_WIDTH, border: 'none' } }}
-        >
-          <Sidebar collapsed={false} onToggle={() => setMobileOpen(false)} />
-        </Drawer>
-      ) : (
+      {!isMobile && (
         <Drawer
           variant="permanent"
           sx={{
@@ -50,9 +39,20 @@ export const AppLayout = () => {
         </Drawer>
       )}
 
-      <Box component="main" sx={{ flexGrow: 1, overflow: 'auto', minWidth: 0 }}>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          overflow: 'auto',
+          minWidth: 0,
+          // Отступ снизу на мобильном чтобы контент не перекрывался нижней навигацией
+          pb: isMobile ? '56px' : 0,
+        }}
+      >
         <Outlet />
       </Box>
+
+      {isMobile && <MobileNav />}
     </Box>
   )
 }

--- a/apps/web/src/widgets/layout/MobileNav.tsx
+++ b/apps/web/src/widgets/layout/MobileNav.tsx
@@ -1,0 +1,69 @@
+import { Box, Paper } from '@mui/material'
+import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
+import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
+import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined'
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
+import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
+import { useNavigate, useLocation } from 'react-router'
+import type { SvgIconComponent } from '@mui/icons-material'
+
+const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string }[] = [
+  { to: '/profile',  icon: AccountCircleOutlinedIcon, label: 'Профиль' },
+  { to: '/library',  icon: AutoStoriesOutlinedIcon,   label: 'Библиотека' },
+  { to: '/feed',     icon: RssFeedOutlinedIcon,       label: 'Лента' },
+  { to: '/friends',  icon: PeopleOutlinedIcon,        label: 'Друзья' },
+  { to: '/search',   icon: SearchOutlinedIcon,        label: 'Поиск' },
+]
+
+/**
+ * Нижняя навигация для мобильных устройств
+ */
+export const MobileNav = () => {
+  const navigate = useNavigate()
+  const { pathname } = useLocation()
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        position: 'fixed',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        zIndex: (theme) => theme.zIndex.appBar,
+      }}
+    >
+      <Box sx={{ display: 'flex', height: 56, bgcolor: 'background.paper' }}>
+        {NAV_ITEMS.map(({ to, icon: Icon, label }) => {
+          const isActive = pathname.startsWith(to)
+          return (
+            <Box
+              key={to}
+              onClick={() => navigate(to)}
+              aria-label={label}
+              sx={{
+                flex: 1,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+                WebkitTapHighlightColor: 'transparent',
+                userSelect: 'none',
+              }}
+            >
+              <Icon
+                sx={{
+                  fontSize: 24,
+                  color: isActive ? 'primary.main' : 'action.disabled',
+                  transition: 'color 0.15s',
+                }}
+              />
+            </Box>
+          )
+        })}
+      </Box>
+    </Paper>
+  )
+}

--- a/apps/web/src/widgets/layout/index.ts
+++ b/apps/web/src/widgets/layout/index.ts
@@ -1,2 +1,3 @@
 export { AppLayout, SIDEBAR_WIDTH, SIDEBAR_COLLAPSED_WIDTH } from './AppLayout'
 export { Sidebar } from './Sidebar'
+export { MobileNav } from './MobileNav'


### PR DESCRIPTION
Мобильная навигация (Фаза 1, пункт 3)

- MobileNav: нижний таб с иконками без подписей
- Активный пункт подсвечивается primary.main (зелёный)
- Неактивные иконки — серые (action.disabled)
- WebkitTapHighlightColor: transparent — нет фона при нажатии
- AppLayout: на мобильном Drawer убран, добавлен pb: 56px под контент

Closes #18