### PR TITLE
Vite proxy setup

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -30,7 +30,14 @@ export default defineConfig({
 
   server: {
     port: 3000,
-    // Автоматически открывает браузер при запуске dev-сервера.
     open: true,
+    proxy: {
+      // Все запросы на /api/* перенаправляются на NestJS.
+      // В продакшне эту роль выполняет nginx.
+      '/api': {
+        target: 'http://localhost:4000',
+        changeOrigin: true,
+      },
+    },
   },
 })


### PR DESCRIPTION
Настройка прокси в Vite (Фаза 2)

Запросы с фронтенда на /api/* проксируются на NestJS (http://localhost:4000).
В продакшне эту роль выполнит nginx.

Closes #35