### PR TITLE
fix(api): add jest and node to tsconfig types for jest globals

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -13,7 +13,8 @@
     // сохранять информацию о типах в runtime — именно так работает DI
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "incremental": true
+    "incremental": true,
+    "types": ["jest", "node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary

Без `"types": ["jest", "node"]` в `tsconfig.json` TypeScript не подхватывает глобальные функции Jest (`describe`, `it`, `expect`, `beforeEach`) — IDE подсвечивает ошибку `Cannot find name 'describe'`, хотя `@types/jest` установлен.

Добавление поля `types` явно указывает TypeScript какие определения типов использовать.

## Test plan

- [ ] Ошибки `Cannot find name` в `app.service.spec.ts` пропали
- [ ] `npm run test --workspace=@treqio/api` → 1 passed