### PR TITLE
feat(api): add google oauth strategy with find-or-create user logic

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,3 +9,6 @@ JWT_REFRESH_SECRET=your_refresh_secret
 GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_CALLBACK_URL=http://localhost:4000/api/auth/google/callback
+
+# Frontend
+FRONTEND_URL=http://localhost:3000

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -26,6 +26,7 @@
     "@prisma/client": "^7.8.0",
     "dotenv": "^17.4.2",
     "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
     "passport-jwt": "^4.0.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2"
@@ -35,6 +36,7 @@
     "@nestjs/testing": "^11.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.3",
+    "@types/passport-google-oauth20": "^2.0.17",
     "@types/passport-jwt": "^4.0.1",
     "jest": "^30.3.0",
     "prisma": "^7.8.0",

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+import type { Request, Response } from 'express'
+import type { User } from '../generated/prisma/client'
+import type { AuthService } from './auth.service'
+
+/**
+ * Контроллер авторизации.
+ */
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  /**
+   * Редирект на страницу авторизации Google.
+   * Passport перехватывает запрос и формирует URL сам — код метода не выполняется.
+   */
+  @Get('google')
+  @UseGuards(AuthGuard('google'))
+  googleLogin(): void {}
+
+  /**
+   * Обработка ответа от Google после авторизации пользователя.
+   * Passport проверил code, получил профиль и положил пользователя в req.user.
+   */
+  @Get('google/callback')
+  @UseGuards(AuthGuard('google'))
+  googleCallback(@Req() req: Request, @Res() res: Response): void {
+    const user = req.user as User
+
+    const accessToken = this.authService.generateAccessToken(user.id)
+    const refreshToken = this.authService.generateRefreshToken(user.id)
+
+    res.cookie('refresh_token', refreshToken, {
+      httpOnly: true, // JS на фронтенде не может прочитать этот cookie
+      secure: false, // true в продакшне (требует HTTPS)
+      sameSite: 'lax',
+      maxAge: 7 * 24 * 60 * 60 * 1000, // 7 дней в миллисекундах
+    })
+
+    const frontendUrl = process.env['FRONTEND_URL'] ?? 'http://localhost:3000'
+    res.redirect(`${frontendUrl}/auth/callback?accessToken=${accessToken}`)
+  }
+}

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,15 +1,19 @@
 import { Module } from '@nestjs/common'
 import { JwtModule } from '@nestjs/jwt'
 import { PassportModule } from '@nestjs/passport'
+import { PrismaModule } from '../prisma/prisma.module'
+import { AuthController } from './auth.controller'
 import { AuthService } from './auth.service'
+import { GoogleStrategy } from './strategies/google.strategy'
 import { JwtStrategy } from './strategies/jwt.strategy'
 
 /**
  * Модуль авторизации.
  */
 @Module({
-  imports: [PassportModule, JwtModule.register({})],
-  providers: [AuthService, JwtStrategy],
+  imports: [PassportModule, JwtModule.register({}), PrismaModule],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy, GoogleStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,12 +1,24 @@
 import { Injectable } from '@nestjs/common'
 import type { JwtService } from '@nestjs/jwt'
+import type { User } from '../generated/prisma/client'
+import type { PrismaService } from '../prisma/prisma.service'
+
+interface GoogleProfile {
+  googleId: string
+  email: string
+  displayName: string
+  avatarUrl: string | null
+}
 
 /**
  * Сервис авторизации.
  */
 @Injectable()
 export class AuthService {
-  constructor(private readonly jwt: JwtService) {}
+  constructor(
+    private readonly jwt: JwtService,
+    private readonly prisma: PrismaService,
+  ) {}
 
   /**
    * Генерация короткоживущего токена для запросов к API (15 минут).
@@ -32,5 +44,47 @@ export class AuthService {
         expiresIn: '7d',
       },
     )
+  }
+
+  /**
+   * Поиск существующего пользователя по Google-аккаунту или создание нового.
+   */
+  async findOrCreateGoogleUser(profile: GoogleProfile): Promise<User> {
+    const existing = await this.prisma.user.findUnique({
+      where: {
+        provider_providerId: {
+          provider: 'google',
+          providerId: profile.googleId,
+        },
+      },
+    })
+
+    if (existing) return existing
+
+    const username = await this.generateUniqueUsername(profile.email.split('@')[0])
+
+    return this.prisma.user.create({
+      data: {
+        email: profile.email,
+        displayName: profile.displayName,
+        username,
+        avatarUrl: profile.avatarUrl,
+        provider: 'google',
+        providerId: profile.googleId,
+      },
+    })
+  }
+
+  /**
+   * Генерация уникального username на основе email-префикса.
+   */
+  private async generateUniqueUsername(base: string): Promise<string> {
+    const clean = base.toLowerCase().replace(/[^a-z0-9]/g, '_')
+    const existing = await this.prisma.user.findUnique({
+      where: { username: clean },
+    })
+    if (!existing) return clean
+    // Добавляем короткий случайный суффикс если username занят
+    return `${clean}_${Date.now().toString(36)}`
   }
 }

--- a/apps/api/src/auth/strategies/google.strategy.ts
+++ b/apps/api/src/auth/strategies/google.strategy.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common'
+import { PassportStrategy } from '@nestjs/passport'
+import type { Profile } from 'passport-google-oauth20'
+import { Strategy } from 'passport-google-oauth20'
+import type { User } from '../../generated/prisma/client'
+import type { AuthService } from '../auth.service'
+
+/**
+ * Стратегия авторизации через Google OAuth 2.0.
+ */
+@Injectable()
+export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
+  constructor(private readonly authService: AuthService) {
+    const clientID = process.env['GOOGLE_CLIENT_ID']
+    const clientSecret = process.env['GOOGLE_CLIENT_SECRET']
+    const callbackURL = process.env['GOOGLE_CALLBACK_URL']
+
+    if (!clientID || !clientSecret || !callbackURL) {
+      throw new Error('Google OAuth env variables are not defined')
+    }
+
+    super({
+      clientID,
+      clientSecret,
+      callbackURL,
+      // Запрашиваем email и базовый профиль (имя, аватар)
+      scope: ['email', 'profile'],
+    })
+  }
+
+  async validate(_accessToken: string, _refreshToken: string, profile: Profile): Promise<User> {
+    return this.authService.findOrCreateGoogleUser({
+      googleId: profile.id,
+      email: profile.emails?.[0]?.value ?? '',
+      displayName: profile.displayName,
+      avatarUrl: profile.photos?.[0]?.value ?? null,
+    })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@prisma/client": "^7.8.0",
         "dotenv": "^17.4.2",
         "passport": "^0.7.0",
+        "passport-google-oauth20": "^2.0.0",
         "passport-jwt": "^4.0.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2"
@@ -49,6 +50,7 @@
         "@nestjs/testing": "^11.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.15.3",
+        "@types/passport-google-oauth20": "^2.0.17",
         "@types/passport-jwt": "^4.0.1",
         "jest": "^30.3.0",
         "prisma": "^7.8.0",
@@ -5708,6 +5710,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/oauth": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.6.tgz",
+      "integrity": "sha512-H9TRCVKBNOhZZmyHLqFt9drPM9l+ShWiqqJijU1B8P3DX3ub84NjxDuy+Hjrz+fEca5Kwip3qPMKNyiLgNJtIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5724,6 +5736,18 @@
         "@types/express": "*"
       }
     },
+    "node_modules/@types/passport-google-oauth20": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport-google-oauth20/-/passport-google-oauth20-2.0.17.tgz",
+      "integrity": "sha512-MHNOd2l7gOTCn3iS+wInPQMiukliAUvMpODO3VlXxOiwNEMSyzV7UNvAdqxSN872o8OXx1SqPDVT6tLW74AtqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
     "node_modules/@types/passport-jwt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
@@ -5733,6 +5757,18 @@
       "dependencies": {
         "@types/jsonwebtoken": "*",
         "@types/passport-strategy": "*"
+      }
+    },
+    "node_modules/@types/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-6//z+4orIOy/g3zx17HyQ71GSRK4bs7Sb+zFasRoc2xzlv7ZCJ+vkDBYFci8U6HY+or6Zy7ajf4mz4rK7nsWJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
       }
     },
     "node_modules/@types/passport-strategy": {
@@ -7332,6 +7368,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.24",
@@ -13651,6 +13696,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -13990,6 +14041,18 @@
         "url": "https://github.com/sponsors/jaredhanson"
       }
     },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/passport-jwt": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
@@ -13998,6 +14061,26 @@
       "dependencies": {
         "jsonwebtoken": "^9.0.0",
         "passport-strategy": "^1.0.0"
+      }
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
       }
     },
     "node_modules/passport-strategy": {
@@ -16575,6 +16658,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT"
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",


### PR DESCRIPTION
## Summary

- Установлены `passport-google-oauth20` и `@types/passport-google-oauth20`
- Создана `GoogleStrategy` — OAuth 2.0 стратегия, запрашивает scopes `email` и `profile`
- `AuthService` — добавлен `findOrCreateGoogleUser()`: ищет по `provider+providerId`, при отсутствии создаёт с автогенерированным `username`
- Создан `AuthController` — маршруты `/auth/google` и `/auth/google/callback`
- Обновлён `AuthModule` — добавлены `GoogleStrategy`, `AuthController`, `PrismaModule`
- `.env` и `.env.example` — добавлена переменная `FRONTEND_URL`

## Test plan

- [ ] `npm run typecheck --workspace=@treqio/api` → без ошибок