### PR TITLE
feat(api): add auth endpoints — me, refresh, logout and jwt guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ A personal media tracker — books, games, movies and more. Track what you've re
 
 ### Backend
 
-| Tool                                         | Purpose           |
-| -------------------------------------------- | ----------------- |
-| [NestJS 11](https://nestjs.com)              | Node.js framework |
-| [TypeScript](https://www.typescriptlang.org) | Type safety       |
-| [Prisma 7](https://www.prisma.io)            | ORM               |
-| [PostgreSQL 16](https://www.postgresql.org)  | Database          |
+| Tool                                                                                    | Purpose                   |
+| --------------------------------------------------------------------------------------- | ------------------------- |
+| [NestJS 11](https://nestjs.com)                                                         | Node.js framework         |
+| [TypeScript](https://www.typescriptlang.org)                                            | Type safety               |
+| [Prisma 7](https://www.prisma.io)                                                       | ORM                       |
+| [PostgreSQL 16](https://www.postgresql.org)                                             | Database                  |
+| [Passport.js](https://www.passportjs.org)                                               | Authentication strategies |
+| [passport-google-oauth20](https://www.passportjs.org/packages/passport-google-oauth20/) | Google OAuth 2.0          |
 
 ### Infrastructure
 
@@ -140,6 +142,9 @@ treqio/
 │   │
 │   └── api/                  # NestJS backend
 │       ├── src/
+│       │   ├── auth/         # Авторизация: стратегии, guards, контроллер, сервис
+│       │   │   ├── guards/   # JwtAuthGuard
+│       │   │   └── strategies/ # JwtStrategy, GoogleStrategy
 │       │   ├── prisma/       # PrismaService + PrismaModule
 │       │   ├── app.module.ts
 │       │   ├── app.controller.ts
@@ -175,10 +180,17 @@ Used by Docker Compose to configure PostgreSQL.
 
 ### `apps/api/.env`
 
-| Variable       | Description              | Example                                                |
-| -------------- | ------------------------ | ------------------------------------------------------ |
-| `PORT`         | API server port          | `4000`                                                 |
-| `DATABASE_URL` | Prisma connection string | `postgresql://postgres:postgres@localhost:5432/treqio` |
+| Variable               | Description                                     | Example                                                |
+| ---------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| `PORT`                 | API server port                                 | `4000`                                                 |
+| `DATABASE_URL`         | Prisma connection string                        | `postgresql://postgres:postgres@localhost:5432/treqio` |
+| `JWT_ACCESS_SECRET`    | Secret for signing access tokens (15 min)       | random 64-byte hex string                              |
+| `JWT_REFRESH_SECRET`   | Secret for signing refresh tokens (7 days)      | random 64-byte hex string                              |
+| `GOOGLE_CLIENT_ID`     | Google OAuth app client ID                      | `xxx.apps.googleusercontent.com`                       |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth app client secret                  | `GOCSPX-xxx`                                           |
+| `GOOGLE_CALLBACK_URL`  | OAuth redirect URI (must match Google Console)  | `http://localhost:4000/api/auth/google/callback`       |
+| `FRONTEND_URL`         | Frontend origin for post-auth redirect          | `http://localhost:3000`                                |
+| `NODE_ENV`             | Runtime environment — set by platform or Docker | `production`                                           |
 
 ---
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,7 @@
+# Среда выполнения — задаётся платформой автоматически (development / production)
+# Не добавляй в .env — значение берётся из окружения
+# NODE_ENV=production
+
 PORT=4000
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/treqio
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,6 +24,7 @@
     "@nestjs/platform-express": "^11.0.0",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
+    "cookie-parser": "^1.4.7",
     "dotenv": "^17.4.2",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@nestjs/cli": "^11.0.0",
     "@nestjs/testing": "^11.0.0",
+    "@types/cookie-parser": "^1.4.10",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.15.3",
     "@types/passport-google-oauth20": "^2.0.17",

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -1,7 +1,17 @@
-import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common'
+import {
+  Controller,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
 import type { Request, Response } from 'express'
 import type { User } from '../generated/prisma/client'
+import { JwtAuthGuard } from './guards/jwt-auth.guard'
 import type { AuthService } from './auth.service'
 
 /**
@@ -33,12 +43,45 @@ export class AuthController {
 
     res.cookie('refresh_token', refreshToken, {
       httpOnly: true, // JS на фронтенде не может прочитать этот cookie
-      secure: false, // true в продакшне (требует HTTPS)
+      secure: process.env['NODE_ENV'] === 'production', // требует HTTPS в продакшне
       sameSite: 'lax',
       maxAge: 7 * 24 * 60 * 60 * 1000, // 7 дней в миллисекундах
     })
 
     const frontendUrl = process.env['FRONTEND_URL'] ?? 'http://localhost:3000'
     res.redirect(`${frontendUrl}/auth/callback?accessToken=${accessToken}`)
+  }
+
+  /**
+   * Данные текущего авторизованного пользователя.
+   */
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  async getMe(@Req() req: Request): Promise<User> {
+    const { userId } = req.user as { userId: string }
+    const user = await this.authService.getUserById(userId)
+    if (!user) throw new NotFoundException('User not found')
+    return user
+  }
+
+  /**
+   * Выдача нового access token по refresh token из cookie.
+   */
+  @Post('refresh')
+  @HttpCode(200)
+  refresh(@Req() req: Request): { accessToken: string } {
+    const token: string = req.cookies?.['refresh_token'] ?? ''
+    const userId = this.authService.verifyRefreshToken(token)
+    return { accessToken: this.authService.generateAccessToken(userId) }
+  }
+
+  /**
+   * Выход из системы — очистка refresh token cookie.
+   */
+  @Post('logout')
+  @HttpCode(200)
+  logout(@Res() res: Response): void {
+    res.clearCookie('refresh_token')
+    res.json({ success: true })
   }
 }

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,12 +1,19 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, UnauthorizedException } from '@nestjs/common'
 import type { JwtService } from '@nestjs/jwt'
 import type { User } from '../generated/prisma/client'
 import type { PrismaService } from '../prisma/prisma.service'
 
+/**
+ * Данные профиля пользователя, полученные от Google OAuth.
+ */
 interface GoogleProfile {
+  /** Уникальный ID пользователя на стороне Google. */
   googleId: string
+  /** Основной email аккаунта. */
   email: string
+  /** Отображаемое имя пользователя. */
   displayName: string
+  /** URL аватара, может отсутствовать. */
   avatarUrl: string | null
 }
 
@@ -73,6 +80,27 @@ export class AuthService {
         providerId: profile.googleId,
       },
     })
+  }
+
+  /**
+   * Поиск пользователя по ID.
+   */
+  async getUserById(userId: string): Promise<User | null> {
+    return this.prisma.user.findUnique({ where: { id: userId } })
+  }
+
+  /**
+   * Проверка refresh token и извлечение userId из payload.
+   */
+  verifyRefreshToken(token: string): string {
+    try {
+      const payload = this.jwt.verify<{ sub: string }>(token, {
+        secret: process.env['JWT_REFRESH_SECRET'],
+      })
+      return payload.sub
+    } catch {
+      throw new UnauthorizedException('Invalid refresh token')
+    }
   }
 
   /**

--- a/apps/api/src/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/auth/guards/jwt-auth.guard.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@nestjs/common'
+import { AuthGuard } from '@nestjs/passport'
+
+/**
+ * Guard для защиты маршрутов — проверяет JWT из заголовка Authorization.
+ */
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,10 +2,14 @@
 // Он добавляет поддержку метаданных декораторов в runtime.
 import 'reflect-metadata'
 import { NestFactory } from '@nestjs/core'
+import cookieParser from 'cookie-parser'
 import { AppModule } from './app.module'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
+
+  // Парсинг cookie — нужен для чтения refresh_token в /auth/refresh
+  app.use(cookieParser())
 
   // Префикс /api для всех маршрутов: /api/health, /api/books и т.д.
   app.setGlobalPrefix('api')

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@nestjs/platform-express": "^11.0.0",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
+        "cookie-parser": "^1.4.7",
         "dotenv": "^17.4.2",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -48,6 +49,7 @@
       "devDependencies": {
         "@nestjs/cli": "^11.0.0",
         "@nestjs/testing": "^11.0.0",
+        "@types/cookie-parser": "^1.4.10",
         "@types/jest": "^30.0.0",
         "@types/node": "^22.15.3",
         "@types/passport-google-oauth20": "^2.0.17",
@@ -5538,6 +5540,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -8192,6 +8204,34 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",


### PR DESCRIPTION
## Summary

- Добавлены endpoints: `GET /auth/me`, `POST /auth/refresh`, `POST /auth/logout`
- `AuthService` — добавлены `getUserById()` и `verifyRefreshToken()`
- Создан `JwtAuthGuard` — защита приватных маршрутов через JWT
- Установлен `cookie-parser` для чтения refresh token из httpOnly cookie
- `secure` для cookie задаётся через `NODE_ENV` — универсально для любой платформы деплоя
- Обновлены README (Backend стек, структура проекта, переменные окружения) и `.env.example`

## Test plan

- [ ] `npm run typecheck --workspace=@treqio/api` → без ошибок