### PR TITLE
feat(api): add swagger with openapi docs and version from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ A personal media tracker — books, games, movies and more. Track what you've re
 
 ---
 
+## Contents
+
+- [Tech Stack](#tech-stack)
+- [Prerequisites](#prerequisites)
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [Environment Variables](#environment-variables)
+- [Available Scripts](#available-scripts)
+- [Development Workflow](#development-workflow)
+- [API](#api)
+
+---
+
 ## Tech Stack
 
 ### Frontend
@@ -22,14 +35,15 @@ A personal media tracker — books, games, movies and more. Track what you've re
 
 ### Backend
 
-| Tool                                                                                    | Purpose                   |
-| --------------------------------------------------------------------------------------- | ------------------------- |
-| [NestJS 11](https://nestjs.com)                                                         | Node.js framework         |
-| [TypeScript](https://www.typescriptlang.org)                                            | Type safety               |
-| [Prisma 7](https://www.prisma.io)                                                       | ORM                       |
-| [PostgreSQL 16](https://www.postgresql.org)                                             | Database                  |
-| [Passport.js](https://www.passportjs.org)                                               | Authentication strategies |
-| [passport-google-oauth20](https://www.passportjs.org/packages/passport-google-oauth20/) | Google OAuth 2.0          |
+| Tool                                                                                    | Purpose                             |
+| --------------------------------------------------------------------------------------- | ----------------------------------- |
+| [NestJS 11](https://nestjs.com)                                                         | Node.js framework                   |
+| [TypeScript](https://www.typescriptlang.org)                                            | Type safety                         |
+| [Prisma 7](https://www.prisma.io)                                                       | ORM                                 |
+| [PostgreSQL 16](https://www.postgresql.org)                                             | Database                            |
+| [Passport.js](https://www.passportjs.org)                                               | Authentication strategies           |
+| [passport-google-oauth20](https://www.passportjs.org/packages/passport-google-oauth20/) | Google OAuth 2.0                    |
+| [Swagger (OpenAPI)](https://swagger.io)                                                 | Interactive API docs at `/api/docs` |
 
 ### Infrastructure
 
@@ -191,6 +205,7 @@ Used by Docker Compose to configure PostgreSQL.
 | `GOOGLE_CALLBACK_URL`  | OAuth redirect URI (must match Google Console)  | `http://localhost:4000/api/auth/google/callback`       |
 | `FRONTEND_URL`         | Frontend origin for post-auth redirect          | `http://localhost:3000`                                |
 | `NODE_ENV`             | Runtime environment — set by platform or Docker | `production`                                           |
+| `SWAGGER_ENABLED`      | Enable Swagger UI at `/api/docs`                | `true`                                                 |
 
 ---
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -16,3 +16,6 @@ GOOGLE_CALLBACK_URL=http://localhost:4000/api/auth/google/callback
 
 # Frontend
 FRONTEND_URL=http://localhost:3000
+
+# Swagger — включить интерактивную документацию на /api/docs (true/false)
+SWAGGER_ENABLED=true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.0",
+    "@nestjs/swagger": "^11.4.2",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
     "cookie-parser": "^1.4.7",

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -9,14 +9,16 @@ import {
   UseGuards,
 } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import type { Request, Response } from 'express'
 import type { User } from '../generated/prisma/client'
-import { JwtAuthGuard } from './guards/jwt-auth.guard'
 import type { AuthService } from './auth.service'
+import { JwtAuthGuard } from './guards/jwt-auth.guard'
 
 /**
  * Контроллер авторизации.
  */
+@ApiTags('auth')
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
@@ -25,6 +27,8 @@ export class AuthController {
    * Редирект на страницу авторизации Google.
    * Passport перехватывает запрос и формирует URL сам — код метода не выполняется.
    */
+  @ApiOperation({ summary: 'Редирект на страницу авторизации Google' })
+  @ApiResponse({ status: 302, description: 'Редирект на Google OAuth' })
   @Get('google')
   @UseGuards(AuthGuard('google'))
   googleLogin(): void {}
@@ -33,6 +37,8 @@ export class AuthController {
    * Обработка ответа от Google после авторизации пользователя.
    * Passport проверил code, получил профиль и положил пользователя в req.user.
    */
+  @ApiOperation({ summary: 'Callback после авторизации через Google' })
+  @ApiResponse({ status: 302, description: 'Редирект на фронтенд с accessToken' })
   @Get('google/callback')
   @UseGuards(AuthGuard('google'))
   googleCallback(@Req() req: Request, @Res() res: Response): void {
@@ -55,6 +61,10 @@ export class AuthController {
   /**
    * Данные текущего авторизованного пользователя.
    */
+  @ApiOperation({ summary: 'Данные текущего пользователя' })
+  @ApiResponse({ status: 200, description: 'Профиль пользователя' })
+  @ApiResponse({ status: 401, description: 'Токен отсутствует или невалидный' })
+  @ApiBearerAuth()
   @Get('me')
   @UseGuards(JwtAuthGuard)
   async getMe(@Req() req: Request): Promise<User> {
@@ -67,6 +77,9 @@ export class AuthController {
   /**
    * Выдача нового access token по refresh token из cookie.
    */
+  @ApiOperation({ summary: 'Обновление access token' })
+  @ApiResponse({ status: 200, description: 'Новый access token' })
+  @ApiResponse({ status: 401, description: 'Refresh token невалидный или истёк' })
   @Post('refresh')
   @HttpCode(200)
   refresh(@Req() req: Request): { accessToken: string } {
@@ -78,6 +91,8 @@ export class AuthController {
   /**
    * Выход из системы — очистка refresh token cookie.
    */
+  @ApiOperation({ summary: 'Выход из системы' })
+  @ApiResponse({ status: 200, description: 'Cookie очищен' })
   @Post('logout')
   @HttpCode(200)
   logout(@Res() res: Response): void {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,8 +2,10 @@
 // Он добавляет поддержку метаданных декораторов в runtime.
 import 'reflect-metadata'
 import { NestFactory } from '@nestjs/core'
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import cookieParser from 'cookie-parser'
 import { AppModule } from './app.module'
+import pkg from '../package.json'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule)
@@ -13,6 +15,19 @@ async function bootstrap() {
 
   // Префикс /api для всех маршрутов: /api/health, /api/books и т.д.
   app.setGlobalPrefix('api')
+
+  // Swagger UI включается явно через переменную окружения
+  if (process.env['SWAGGER_ENABLED'] === 'true') {
+    const config = new DocumentBuilder()
+      .setTitle('Treqio API')
+      .setDescription('REST API приложения Treqio')
+      .setVersion(pkg.version)
+      .addBearerAuth()
+      .build()
+
+    const document = SwaggerModule.createDocument(app, config)
+    SwaggerModule.setup('api/docs', app, document)
+  }
 
   const port = process.env['PORT'] ?? 4000
   await app.listen(port)

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,7 +14,8 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "incremental": true,
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "resolveJsonModule": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.0",
+        "@nestjs/swagger": "^11.4.2",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
         "cookie-parser": "^1.4.7",
@@ -3570,6 +3571,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-9.0.0.tgz",
@@ -3901,6 +3908,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/@nestjs/passport/-/passport-11.0.5.tgz",
@@ -3951,6 +3978,39 @@
       },
       "peerDependenciesMeta": {
         "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.2.tgz",
+      "integrity": "sha512-aBihEogDMj/bLEcaqhkvyX/ZVWUw/bmnhKzR0zwUoyGJikvZyaq7rOPYl/H7Lxkkr3c90SJxyuv1AX2UT1WKlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "4.1.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         }
       }
@@ -5176,6 +5236,13 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
@@ -7007,7 +7074,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -12477,7 +12543,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -12897,7 +12962,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -16009,6 +16073,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {


### PR DESCRIPTION
## Summary

- Установлен `@nestjs/swagger`
- Swagger UI подключён в `main.ts` — доступен на `/api/docs` при `SWAGGER_ENABLED=true`
- Версия берётся из `apps/api/package.json` автоматически через `resolveJsonModule`
- Добавлены аннотации `@ApiTags`, `@ApiOperation`, `@ApiResponse`, `@ApiBearerAuth` к auth endpoints
- `SWAGGER_ENABLED` добавлена в `.env` и `.env.example`
- README: добавлено содержание, Swagger в Tech Stack, `SWAGGER_ENABLED` в переменные окружения

## Test plan

- [ ] `npm run typecheck --workspace=@treqio/api` → без ошибок
- [ ] `npm run api` → открыть `http://localhost:4000/api/docs` → Swagger UI отображается