### PR TITLE
feat(web): add frontend auth — login page, authslice, protected routes, token refresh

### DIFF
--- a/apps/api/eslint.config.mjs
+++ b/apps/api/eslint.config.mjs
@@ -11,9 +11,7 @@ export default tseslint.config(
     rules: {
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/consistent-type-imports': ['error', { prefer: 'type-imports' }],
-      // NestJS DI требует реальных импортов классов (не type-only) —
-      // reflect-metadata читает их в runtime для внедрения зависимостей
+      // NestJS DI требует реальных импортов классов — reflect-metadata читает их в runtime
       '@typescript-eslint/consistent-type-imports': 'off',
       '@typescript-eslint/no-extraneous-class': 'off',
     },

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -12,7 +12,7 @@ import { AuthGuard } from '@nestjs/passport'
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger'
 import type { Request, Response } from 'express'
 import type { User } from '../generated/prisma/client'
-import type { AuthService } from './auth.service'
+import { AuthService } from './auth.service'
 import { JwtAuthGuard } from './guards/jwt-auth.guard'
 
 /**

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common'
-import type { JwtService } from '@nestjs/jwt'
+import { JwtService } from '@nestjs/jwt'
 import type { User } from '../generated/prisma/client'
-import type { PrismaService } from '../prisma/prisma.service'
+import { PrismaService } from '../prisma/prisma.service'
 
 /**
  * Данные профиля пользователя, полученные от Google OAuth.

--- a/apps/api/src/auth/strategies/google.strategy.ts
+++ b/apps/api/src/auth/strategies/google.strategy.ts
@@ -3,7 +3,7 @@ import { PassportStrategy } from '@nestjs/passport'
 import type { Profile } from 'passport-google-oauth20'
 import { Strategy } from 'passport-google-oauth20'
 import type { User } from '../../generated/prisma/client'
-import type { AuthService } from '../auth.service'
+import { AuthService } from '../auth.service'
 
 /**
  * Стратегия авторизации через Google OAuth 2.0.

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,6 @@
-// reflect-metadata должен быть импортирован первым — до любых NestJS импортов.
+// dotenv должен быть импортирован первым — загружает .env в process.env до инициализации NestJS.
+import 'dotenv/config'
+// reflect-metadata должен быть импортирован до любых NestJS импортов.
 // Он добавляет поддержку метаданных декораторов в runtime.
 import 'reflect-metadata'
 import { NestFactory } from '@nestjs/core'

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:4000/api

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,11 +1,14 @@
+import { AuthProvider } from './app/providers/AuthProvider'
+import { RouterProvider } from './app/providers/RouterProvider'
 import { StoreProvider } from './app/providers/StoreProvider'
 import { ThemeProvider } from './app/providers/ThemeProvider'
-import { RouterProvider } from './app/providers/RouterProvider'
 
 export const App = () => (
   <StoreProvider>
     <ThemeProvider>
-      <RouterProvider />
+      <AuthProvider>
+        <RouterProvider />
+      </AuthProvider>
     </ThemeProvider>
   </StoreProvider>
 )

--- a/apps/web/src/app/providers/AuthProvider.tsx
+++ b/apps/web/src/app/providers/AuthProvider.tsx
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { useAppDispatch } from '@/shared/lib/store'
+import { setCredentials, setInitialized } from '@/features/auth'
+
+/**
+ * Пропсы провайдера авторизации.
+ */
+interface Props {
+  /** Дочерние компоненты приложения. */
+  children: React.ReactNode
+}
+
+/**
+ * Восстановление сессии при старте приложения через refresh token cookie.
+ */
+export function AuthProvider({ children }: Props) {
+  const dispatch = useAppDispatch()
+
+  // При монтировании пробуем получить новый access token по refresh token из cookie.
+  // Если cookie валиден — пользователь восстанавливает сессию без повторного логина.
+  useEffect(() => {
+    const restoreSession = async () => {
+      try {
+        const res = await fetch('/api/auth/refresh', {
+          method: 'POST',
+          credentials: 'include',
+        })
+
+        if (res.ok) {
+          const { accessToken } = (await res.json()) as { accessToken: string }
+          dispatch(setCredentials({ accessToken }))
+        }
+      } finally {
+        // Помечаем инициализацию завершённой в любом случае — даже если refresh не прошёл
+        dispatch(setInitialized())
+      }
+    }
+
+    void restoreSession()
+  }, [dispatch])
+
+  return <>{children}</>
+}

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,21 +1,56 @@
-import { createBrowserRouter, Navigate } from 'react-router'
-import { AppLayout } from '@/widgets/layout'
+import { createBrowserRouter, Navigate, Outlet } from 'react-router'
+import { Box, CircularProgress } from '@mui/material'
+import { AuthCallbackPage } from '@/pages/auth-callback'
 import { LibraryPage } from '@/pages/library'
+import { LoginPage } from '@/pages/login'
 import { ProfilePage } from '@/pages/profile'
+import { useAppSelector } from '@/shared/lib/store'
+import { AppLayout } from '@/widgets/layout'
 
 /**
- * Маршруты приложения
+ * Защита приватных роутов — редирект на /login если пользователь не авторизован.
+ */
+function RequireAuth() {
+  const { accessToken, isInitialized } = useAppSelector((s) => s.auth)
+
+  // Ждём завершения проверки сессии в AuthProvider перед редиректом
+  if (!isInitialized) {
+    return (
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}
+      >
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (!accessToken) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <Outlet />
+}
+
+/**
+ * Маршруты приложения.
  */
 export const router = createBrowserRouter([
+  // Публичные маршруты
+  { path: '/login', element: <LoginPage /> }, // Страница входа
+  { path: '/auth/callback', element: <AuthCallbackPage /> }, // Обработчик OAuth редиректа
+
+  // Приватные маршруты
   {
-    path: '/',
-    element: <Navigate to="/library" replace />,
-  },
-  {
-    element: <AppLayout />,
+    element: <RequireAuth />,
     children: [
-      { path: '/library', element: <LibraryPage /> },
-      { path: '/profile', element: <ProfilePage /> },
+      { path: '/', element: <Navigate to="/library" replace /> },
+      {
+        element: <AppLayout />,
+        children: [
+          { path: '/library', element: <LibraryPage /> }, // Библиотека
+          { path: '/profile', element: <ProfilePage /> }, // Профиль пользователя
+        ],
+      },
     ],
   },
 ])

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -1,23 +1,24 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { authReducer } from '@/features/auth'
 import { baseApi } from '@/shared/api/baseApi'
 
 /**
- * Redux store приложения
+ * Redux store приложения.
  */
 export const store = configureStore({
   reducer: {
+    auth: authReducer,
     [baseApi.reducerPath]: baseApi.reducer,
   },
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware().concat(baseApi.middleware),
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(baseApi.middleware),
 })
 
 /**
- * Тип всего состояния приложения
+ * Тип всего состояния приложения.
  */
 export type RootState = ReturnType<typeof store.getState>
 
 /**
- * Тип dispatch со всеми зарегистрированными экшенами
+ * Тип dispatch со всеми зарегистрированными экшенами.
  */
 export type AppDispatch = typeof store.dispatch

--- a/apps/web/src/entities/user/index.ts
+++ b/apps/web/src/entities/user/index.ts
@@ -1,0 +1,1 @@
+export type { User } from './model/user.types'

--- a/apps/web/src/entities/user/model/user.types.ts
+++ b/apps/web/src/entities/user/model/user.types.ts
@@ -1,0 +1,23 @@
+/**
+ * Пользователь приложения.
+ */
+export interface User {
+  /** Уникальный идентификатор. */
+  id: string
+  /** Уникальный публичный username для URL профиля. */
+  username: string
+  /** Отображаемое имя. */
+  displayName: string
+  /** Email аккаунта. */
+  email: string
+  /** URL аватара от OAuth-провайдера. */
+  avatarUrl: string | null
+  /** Краткое описание профиля. */
+  bio: string | null
+  /** OAuth-провайдер: 'google' | 'github'. */
+  provider: string
+  /** Дата регистрации. */
+  createdAt: string
+  /** Дата последнего обновления профиля. */
+  updatedAt: string
+}

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,0 +1,2 @@
+export { default as authReducer } from './model/authSlice'
+export { setCredentials, setUser, logout, setInitialized } from './model/authSlice'

--- a/apps/web/src/features/auth/model/authSlice.ts
+++ b/apps/web/src/features/auth/model/authSlice.ts
@@ -1,0 +1,67 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import type { User } from '@/entities/user'
+
+/**
+ * Состояние авторизации в Redux store.
+ */
+interface AuthState {
+  /** Данные авторизованного пользователя. */
+  user: User | null
+  /** JWT access token для запросов к API. */
+  accessToken: string | null
+  /** Флаг завершения начальной проверки сессии. */
+  isInitialized: boolean
+}
+
+/** Начальное состояние. */
+const initialState: AuthState = {
+  user: null,
+  accessToken: null,
+  isInitialized: false,
+}
+
+/**
+ * Slice авторизации.
+ */
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    /**
+     * Сохранение токена и опционально данных пользователя после логина или refresh.
+     */
+    setCredentials: (state, action: PayloadAction<{ accessToken: string; user?: User }>) => {
+      state.accessToken = action.payload.accessToken
+      if (action.payload.user) {
+        state.user = action.payload.user
+      }
+    },
+
+    /**
+     * Обновление данных пользователя после запроса /auth/me.
+     */
+    setUser: (state, action: PayloadAction<User>) => {
+      state.user = action.payload
+    },
+
+    /**
+     * Очистка сессии при выходе из системы.
+     */
+    logout: (state) => {
+      state.user = null
+      state.accessToken = null
+    },
+
+    /**
+     * Отметка что начальная проверка сессии завершена.
+     */
+    setInitialized: (state) => {
+      state.isInitialized = true
+    },
+  },
+})
+
+export const { setCredentials, setUser, logout, setInitialized } = authSlice.actions
+
+export default authSlice.reducer

--- a/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react'
+import { useNavigate, useSearchParams } from 'react-router'
+import { Box, CircularProgress } from '@mui/material'
+import type { User } from '@/entities/user'
+import { setCredentials, setUser } from '@/features/auth'
+import { useAppDispatch } from '@/shared/lib/store'
+
+/**
+ * Обработчик редиректа после OAuth авторизации.
+ */
+export function AuthCallbackPage() {
+  const [searchParams] = useSearchParams()
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
+
+  // Читает accessToken из URL, загружает профиль пользователя, перенаправляет на главную
+  useEffect(() => {
+    const accessToken = searchParams.get('accessToken')
+
+    if (!accessToken) {
+      void navigate('/login', { replace: true })
+      return
+    }
+
+    const fetchUser = async () => {
+      try {
+        dispatch(setCredentials({ accessToken }))
+
+        const res = await fetch('/api/auth/me', {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          credentials: 'include',
+        })
+
+        if (res.ok) {
+          const user = (await res.json()) as User
+          dispatch(setUser(user))
+        }
+      } finally {
+        void navigate('/', { replace: true })
+      }
+    }
+
+    void fetchUser()
+  }, [searchParams, dispatch, navigate])
+
+  return (
+    <Box
+      sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', minHeight: '100vh' }}
+    >
+      <CircularProgress />
+    </Box>
+  )
+}

--- a/apps/web/src/pages/auth-callback/index.ts
+++ b/apps/web/src/pages/auth-callback/index.ts
@@ -1,0 +1,1 @@
+export { AuthCallbackPage } from './AuthCallbackPage'

--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -1,0 +1,30 @@
+import { Box, Button, Typography } from '@mui/material'
+
+const API_URL = import.meta.env['VITE_API_URL'] as string
+
+/**
+ * Страница входа в приложение.
+ */
+export function LoginPage() {
+  const handleGoogleLogin = () => {
+    window.location.href = `${API_URL}/auth/google`
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        gap: 3,
+      }}
+    >
+      <Typography variant="h4">Treqio</Typography>
+      <Button variant="contained" size="large" onClick={handleGoogleLogin}>
+        Войти через Google
+      </Button>
+    </Box>
+  )
+}

--- a/apps/web/src/pages/login/index.ts
+++ b/apps/web/src/pages/login/index.ts
@@ -1,0 +1,1 @@
+export { LoginPage } from './LoginPage'

--- a/apps/web/src/shared/api/baseApi.ts
+++ b/apps/web/src/shared/api/baseApi.ts
@@ -1,21 +1,56 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolkit/query'
+import { logout, setCredentials } from '@/features/auth'
+import type { RootState } from '@/app/store'
+
+/** Базовый fetch с токеном из store и автоматической отправкой cookie. */
+const baseQuery = fetchBaseQuery({
+  baseUrl: '/api',
+  credentials: 'include', // отправляет httpOnly cookie с refresh token автоматически
+  prepareHeaders: (headers, { getState }) => {
+    const token = (getState() as RootState).auth.accessToken
+    if (token) {
+      headers.set('authorization', `Bearer ${token}`)
+    }
+    return headers
+  },
+})
 
 /**
- * Базовый API-клиент
+ * Базовый запрос с автоматическим обновлением access token при 401.
+ */
+const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQueryError> = async (
+  args,
+  api,
+  extraOptions,
+) => {
+  let result = await baseQuery(args, api, extraOptions)
+
+  if (result.error?.status === 401) {
+    const refreshResult = await baseQuery(
+      { url: '/auth/refresh', method: 'POST' },
+      api,
+      extraOptions,
+    )
+
+    if (refreshResult.data) {
+      const { accessToken } = refreshResult.data as { accessToken: string }
+      api.dispatch(setCredentials({ accessToken }))
+      result = await baseQuery(args, api, extraOptions)
+    } else {
+      api.dispatch(logout())
+    }
+  }
+
+  return result
+}
+
+/**
+ * Базовый API-клиент.
  */
 export const baseApi = createApi({
   reducerPath: 'api',
-  baseQuery: fetchBaseQuery({
-    baseUrl: '/api',
-    prepareHeaders: (headers) => {
-      const token = localStorage.getItem('access_token')
-      if (token) {
-        headers.set('authorization', `Bearer ${token}`)
-      }
-      return headers
-    },
-  }),
-  // При мутации с тегом 'Book' все запросы помеченные 'Book' автоматически перезапрашиваются
+  baseQuery: baseQueryWithReauth,
   tagTypes: ['Book', 'User', 'Feed', 'Friend'],
   endpoints: () => ({}),
 })

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,4 +15,11 @@ export default tseslint.config(
       'no-console': ['warn', { allow: ['warn', 'error'] }],
     },
   },
+  {
+    // NestJS DI требует реальных импортов классов — reflect-metadata читает их в runtime
+    files: ['apps/api/**'],
+    rules: {
+      '@typescript-eslint/consistent-type-imports': 'off',
+    },
+  },
 )


### PR DESCRIPTION
## Summary

- Создан `authSlice` — хранит `user`, `accessToken`, `isInitialized` в Redux store
- Добавлен `AuthProvider` — восстанавливает сессию при старте через refresh token cookie
- Создана страница `/login` с кнопкой Google OAuth
- Создана страница `/auth/callback` — обрабатывает редирект от бэкенда, читает token из URL
- `RequireAuth` — защищает приватные роуты, показывает лоадер до завершения инициализации
- `baseApi` — читает токен из Redux store, автоматически обновляет при 401
- Добавлен тип `User` в `entities/user` по FSD
- Фикс: `import 'dotenv/config'` в `main.ts` — API теперь корректно читает `.env`
- Фикс: корневой ESLint конфиг — `consistent-type-imports` отключён для `apps/api` (NestJS DI требует реальных импортов)

## Test plan

- [ ] `npm run dev` → открыть `http://localhost:3000` → редирект на `/login`
- [ ] Нажать «Войти через Google» → авторизоваться → редирект на `/library`
- [ ] Обновить страницу — остаться авторизованным (сессия восстанавливается через cookie)