### PR TITLE
feat(web): add mui theme augmentation, multi-theme support and sidebar palette tokens

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -1,20 +1,27 @@
-import { ThemeProvider as MuiThemeProvider, CssBaseline } from '@mui/material'
+import { CssBaseline, ThemeProvider as MuiThemeProvider } from '@mui/material'
 import type { ReactNode } from 'react'
-import { theme } from '../styles/theme'
+import { useAppSelector } from '@/shared/lib/store'
+import { buildTheme } from '../styles/theme'
 
+/**
+ * Свойства провайдера темы.
+ */
 interface Props {
-  /**
-   * Дерево компонентов с доступом к теме
-   */
+  /** Дочерние компоненты с доступом к теме. */
   children: ReactNode
 }
 
 /**
- * Оборачивает приложение MUI ThemeProvider и сбрасывает браузерные стили через CssBaseline
+ * Оборачивает приложение MUI ThemeProvider с текущей темой из store.
  */
-export const ThemeProvider = ({ children }: Props) => (
-  <MuiThemeProvider theme={theme}>
-    <CssBaseline />
-    {children}
-  </MuiThemeProvider>
-)
+export const ThemeProvider = ({ children }: Props) => {
+  const variant = useAppSelector((s) => s.theme.variant)
+  const theme = buildTheme(variant)
+
+  return (
+    <MuiThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </MuiThemeProvider>
+  )
+}

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { authReducer } from '@/features/auth'
 import { baseApi } from '@/shared/api/baseApi'
+import themeReducer from './store/themeSlice'
 
 /**
  * Redux store приложения.
@@ -8,6 +9,7 @@ import { baseApi } from '@/shared/api/baseApi'
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    theme: themeReducer,
     [baseApi.reducerPath]: baseApi.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(baseApi.middleware),

--- a/apps/web/src/app/store/themeSlice.ts
+++ b/apps/web/src/app/store/themeSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { DEFAULT_THEME } from '@/app/styles/theme'
+import type { ThemeVariant } from '@/app/styles/theme'
+
+const STORAGE_KEY = 'treqio_theme'
+
+/**
+ * Состояние темы приложения.
+ */
+interface ThemeState {
+  /** Текущий вариант палитры. */
+  variant: ThemeVariant
+}
+
+/** Начальное состояние — читаем из localStorage, иначе дефолт. */
+const initialState: ThemeState = {
+  variant: (localStorage.getItem(STORAGE_KEY) as ThemeVariant | null) ?? DEFAULT_THEME,
+}
+
+/**
+ * Slice управления темой приложения.
+ */
+const themeSlice = createSlice({
+  name: 'theme',
+  initialState,
+  reducers: {
+    /**
+     * Смена варианта палитры. Сохраняет выбор в localStorage.
+     */
+    setTheme: (state, action: PayloadAction<ThemeVariant>) => {
+      state.variant = action.payload
+      localStorage.setItem(STORAGE_KEY, action.payload)
+    },
+  },
+})
+
+export const { setTheme } = themeSlice.actions
+export default themeSlice.reducer

--- a/apps/web/src/app/styles/theme.ts
+++ b/apps/web/src/app/styles/theme.ts
@@ -1,47 +1,78 @@
 import { createTheme } from '@mui/material/styles'
 
 /**
- * Цвета сайдбара — вынесены отдельно, т.к. сайдбар имеет собственный тёмный фон
- * и не вписывается в стандартную MUI palette
+ * Расширяем MUI Palette своими токенами.
+ * После этого theme.palette.sidebar.* доступен везде с типизацией.
  */
-export const sidebarColors = {
-  bg:       '#243D35', // фон сайдбара
-  text:     '#D8EBE4', // основной текст и иконки
-  muted:    'rgba(216,235,228,0.5)', // неактивные пункты меню
-  activeBg: 'rgba(255,255,255,0.09)', // фон активного/hovered пункта
-  divider:  'rgba(255,255,255,0.07)', // разделительные линии
+declare module '@mui/material/styles' {
+  /**
+   * Расширяет тип palette — добавляет доступ к theme.palette.sidebar.*.
+   */
+  interface Palette {
+    sidebar: SidebarPalette
+  }
+  /**
+   * Расширяет тип опций createTheme — позволяет передавать sidebar при создании темы.
+   */
+  interface PaletteOptions {
+    sidebar?: Partial<SidebarPalette>
+  }
 }
 
 /**
- * Тема приложения — палитра Sage Library
+ * Цвета тёмного сайдбара и hero-секций.
+ */
+interface SidebarPalette {
+  /** Фон сайдбара. */
+  bg: string
+  /** Основной текст и иконки. */
+  text: string
+  /** Неактивные пункты меню. */
+  muted: string
+  /** Фон активного / hovered пункта. */
+  activeBg: string
+  /** Разделительные линии. */
+  divider: string
+}
+
+/**
+ * Тема приложения — палитра Sage Library.
  */
 export const theme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main:         '#4E7B6A', // основной акцент — кнопки, ссылки, чекбоксы
-      light:        '#6E9B8A', // светлый вариант для hover-состояний
-      dark:         '#3D6A59', // тёмный вариант для pressed-состояний
-      contrastText: '#FAFCF9', // текст поверх primary-цвета
+      main: '#4E7B6A',
+      light: '#6E9B8A',
+      dark: '#3D6A59',
+      contrastText: '#FAFCF9',
     },
     secondary: {
-      main:         '#8B7355', // вторичный акцент — теги, метки
-      light:        '#A89070',
-      dark:         '#6E5A40',
+      main: '#8B7355',
+      light: '#A89070',
+      dark: '#6E5A40',
       contrastText: '#FAFCF9',
     },
     background: {
-      default: '#F2F5F1', // фон страницы
-      paper:   '#FAFCF9', // фон карточек, модалок, дропдаунов
+      default: '#F2F5F1',
+      paper: '#FAFCF9',
     },
     text: {
-      primary:   '#1E3328', // основной текст
-      secondary: '#5A7A6A', // вспомогательный текст, подписи
+      primary: '#1E3328',
+      secondary: '#5A7A6A',
     },
-    divider: '#D5E4D8', // разделители между секциями
-    error:   { main: '#B94040' },
+    divider: '#D5E4D8',
+    error: { main: '#B94040' },
     warning: { main: '#C49A3A' },
     success: { main: '#4E7B6A' },
+
+    sidebar: {
+      bg: '#243D35',
+      text: '#D8EBE4',
+      muted: 'rgba(216,235,228,0.5)',
+      activeBg: 'rgba(255,255,255,0.09)',
+      divider: 'rgba(255,255,255,0.07)',
+    },
   },
 
   typography: {
@@ -57,9 +88,12 @@ export const theme = createTheme({
 
   components: {
     MuiButton: {
+      defaultProps: {
+        disableElevation: true,
+      },
       styleOverrides: {
         root: {
-          textTransform: 'none', // убираем ALL CAPS — дефолт MUI
+          textTransform: 'none',
           fontWeight: 500,
         },
       },

--- a/apps/web/src/app/styles/theme.ts
+++ b/apps/web/src/app/styles/theme.ts
@@ -1,9 +1,6 @@
 import { createTheme } from '@mui/material/styles'
+import type { PaletteOptions } from '@mui/material/styles'
 
-/**
- * Расширяем MUI Palette своими токенами.
- * После этого theme.palette.sidebar.* доступен везде с типизацией.
- */
 declare module '@mui/material/styles' {
   /**
    * Расширяет тип palette — добавляет доступ к theme.palette.sidebar.*.
@@ -19,97 +16,159 @@ declare module '@mui/material/styles' {
   }
 }
 
+// ─── Типы ─────────────────────────────────────────────────────────────────────
+
 /**
  * Цвета тёмного сайдбара и hero-секций.
  */
 interface SidebarPalette {
   /** Фон сайдбара. */
-  bg: string
+  background: string
   /** Основной текст и иконки. */
   text: string
   /** Неактивные пункты меню. */
   muted: string
   /** Фон активного / hovered пункта. */
-  activeBg: string
+  activeBackground: string
   /** Разделительные линии. */
   divider: string
 }
 
 /**
- * Тема приложения — палитра Sage Library.
+ * Доступные варианты темы приложения.
  */
-export const theme = createTheme({
-  palette: {
-    mode: 'light',
+export type ThemeVariant = 'sageLibrary' | 'warmLatte' | 'slate' | 'dustyPlum'
+
+// ─── Палитры ──────────────────────────────────────────────────────────────────
+
+/**
+ * Токены каждого варианта темы.
+ */
+const palettes: Record<ThemeVariant, PaletteOptions> = {
+  sageLibrary: {
     primary: {
-      main: '#4E7B6A',
-      light: '#6E9B8A',
-      dark: '#3D6A59',
-      contrastText: '#FAFCF9',
+      main: '#4E7B6A', // основной акцент
+      light: '#6E9B8A', // светлый вариант для hover
+      dark: '#3D6A59', // тёмный вариант для pressed
+      contrastText: '#FAFCF9', // цвет текста на primary-кнопках
     },
     secondary: {
-      main: '#8B7355',
-      light: '#A89070',
-      dark: '#6E5A40',
-      contrastText: '#FAFCF9',
+      main: '#8B7355', // вторичный акцент
+      light: '#A89070', // светлый вариант
+      dark: '#6E5A40', // тёмный вариант
+      contrastText: '#FAFCF9', // цвет текста на secondary-кнопках
     },
     background: {
-      default: '#F2F5F1',
-      paper: '#FAFCF9',
+      default: '#F2F5F1', // фон страницы
+      paper: '#FAFCF9', // фон карточек и поверхностей
     },
     text: {
-      primary: '#1E3328',
-      secondary: '#5A7A6A',
+      primary: '#1E3328', // основной текст
+      secondary: '#5A7A6A', // вспомогательный текст
     },
-    divider: '#D5E4D8',
-    error: { main: '#B94040' },
-    warning: { main: '#C49A3A' },
-    success: { main: '#4E7B6A' },
-
+    divider: '#D5E4D8', // разделители между секциями
     sidebar: {
-      bg: '#243D35',
-      text: '#D8EBE4',
-      muted: 'rgba(216,235,228,0.5)',
-      activeBg: 'rgba(255,255,255,0.09)',
+      background: '#243D35', // фон сайдбара
+      text: '#D8EBE4', // текст и иконки
+      muted: 'rgba(216,235,228,0.5)', // неактивные пункты меню
+      activeBackground: 'rgba(255,255,255,0.09)', // фон активного пункта
+      divider: 'rgba(255,255,255,0.07)', // разделительные линии
+    },
+  },
+
+  warmLatte: {
+    primary: { main: '#8B5E3C', light: '#A87D5A', dark: '#7A5234', contrastText: '#FFF8F2' },
+    secondary: { main: '#7A5C45', light: '#9A7A62', dark: '#5E4432', contrastText: '#FFF8F2' },
+    background: { default: '#FAF6F0', paper: '#FFF8F2' },
+    text: { primary: '#2C1810', secondary: '#7A5C45' },
+    divider: '#E8DDD0',
+    sidebar: {
+      background: '#2C1810',
+      text: '#E8DDD0',
+      muted: 'rgba(232,221,208,0.5)',
+      activeBackground: 'rgba(255,255,255,0.10)',
       divider: 'rgba(255,255,255,0.07)',
     },
   },
 
-  typography: {
-    fontFamily: '"Inter", "Segoe UI", system-ui, sans-serif',
-    h1: { fontWeight: 700, letterSpacing: '-0.025em' },
-    h2: { fontWeight: 600, letterSpacing: '-0.02em' },
-    h3: { fontWeight: 600, letterSpacing: '-0.01em' },
-    body1: { lineHeight: 1.6 },
-    body2: { lineHeight: 1.5 },
-  },
-
-  shape: { borderRadius: 10 },
-
-  components: {
-    MuiButton: {
-      defaultProps: {
-        disableElevation: true,
-      },
-      styleOverrides: {
-        root: {
-          textTransform: 'none',
-          fontWeight: 500,
-        },
-      },
-    },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          border: '1px solid #D5E4D8',
-          boxShadow: '0px 2px 8px rgba(30,51,40,0.07)',
-        },
-      },
-    },
-    MuiChip: {
-      styleOverrides: {
-        root: { borderRadius: 6 },
-      },
+  slate: {
+    primary: { main: '#4361B0', light: '#6481C8', dark: '#3451A0', contrastText: '#FFFFFF' },
+    secondary: { main: '#5A6580', light: '#7A85A0', dark: '#3A4560', contrastText: '#FFFFFF' },
+    background: { default: '#F7F8FA', paper: '#FFFFFF' },
+    text: { primary: '#1A2035', secondary: '#5A6580' },
+    divider: '#E2E6EF',
+    sidebar: {
+      background: '#1E2535',
+      text: '#CBD5E8',
+      muted: 'rgba(203,213,232,0.5)',
+      activeBackground: 'rgba(255,255,255,0.08)',
+      divider: 'rgba(255,255,255,0.07)',
     },
   },
-})
+
+  dustyPlum: {
+    primary: { main: '#7C5CA8', light: '#9C7CC8', dark: '#6B4C97', contrastText: '#FFFFFF' },
+    secondary: { main: '#6B5880', light: '#8B78A0', dark: '#4B3860', contrastText: '#FFFFFF' },
+    background: { default: '#F6F4FA', paper: '#FDFBFF' },
+    text: { primary: '#1E1530', secondary: '#6B5880' },
+    divider: '#E3DCF0',
+    sidebar: {
+      background: '#2D1F45',
+      text: '#DDD5EE',
+      muted: 'rgba(221,213,238,0.5)',
+      activeBackground: 'rgba(255,255,255,0.09)',
+      divider: 'rgba(255,255,255,0.07)',
+    },
+  },
+}
+
+// ─── Фабрика ──────────────────────────────────────────────────────────────────
+
+/**
+ * Создаёт MUI тему для заданного варианта палитры.
+ */
+export function buildTheme(variant: ThemeVariant) {
+  return createTheme({
+    palette: {
+      mode: 'light',
+      ...palettes[variant],
+      error: { main: '#B94040' },
+      warning: { main: '#C49A3A' },
+      success: palettes[variant].primary,
+    },
+
+    typography: {
+      fontFamily: '"Inter", "Segoe UI", system-ui, sans-serif',
+      h1: { fontWeight: 700, letterSpacing: '-0.025em' },
+      h2: { fontWeight: 600, letterSpacing: '-0.02em' },
+      h3: { fontWeight: 600, letterSpacing: '-0.01em' },
+      body1: { lineHeight: 1.6 },
+      body2: { lineHeight: 1.5 },
+    },
+
+    shape: { borderRadius: 10 },
+
+    components: {
+      MuiButton: {
+        defaultProps: { disableElevation: true },
+        styleOverrides: {
+          root: { textTransform: 'none', fontWeight: 500 },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            border: `1px solid ${palettes[variant].divider}`,
+            boxShadow: '0px 2px 8px rgba(0,0,0,0.07)',
+          },
+        },
+      },
+      MuiChip: {
+        styleOverrides: { root: { borderRadius: 6 } },
+      },
+    },
+  })
+}
+
+/** Дефолтная тема приложения. */
+export const DEFAULT_THEME: ThemeVariant = 'sageLibrary'

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -11,9 +11,15 @@ import { Box, IconButton, List, Typography } from '@mui/material'
 import { useTheme } from '@mui/material/styles'
 import { Link, useMatch } from 'react-router'
 
+/**
+ * Конфигурация одного пункта навигации.
+ */
 interface NavItemConfig {
+  /** Путь роута. */
   to: string
+  /** Иконка MUI. */
   icon: SvgIconComponent
+  /** Подпись пункта меню. */
   label: string
 }
 
@@ -29,7 +35,11 @@ const FOOTER_ITEMS: NavItemConfig[] = [
   { to: '/settings', icon: SettingsOutlinedIcon, label: 'Настройки' },
 ]
 
+/**
+ * Свойства пункта навигации с состоянием сайдбара.
+ */
 interface NavItemProps extends NavItemConfig {
+  /** Флаг свёрнутости сайдбара. */
   collapsed: boolean
 }
 
@@ -51,12 +61,12 @@ const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
         borderRadius: '8px',
         textDecoration: 'none',
         color: isActive ? s.text : s.muted,
-        bgcolor: isActive ? s.activeBg : 'transparent',
+        bgcolor: isActive ? s.activeBackground : 'transparent',
         justifyContent: collapsed ? 'center' : 'flex-start',
         cursor: 'pointer',
         flexShrink: 0,
         transition: 'background 0.15s, color 0.15s',
-        '&:hover': { bgcolor: s.activeBg, color: s.text },
+        '&:hover': { bgcolor: s.activeBackground, color: s.text },
       }}
     >
       <Icon sx={{ fontSize: 22, flexShrink: 0 }} />
@@ -69,8 +79,13 @@ const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
   )
 }
 
+/**
+ * Свойства сайдбара.
+ */
 interface Props {
+  /** Флаг свёрнутости сайдбара. */
   collapsed: boolean
+  /** Функция переключения состояния свёрнутости. */
   onToggle: () => void
 }
 
@@ -85,7 +100,7 @@ export const Sidebar = ({ collapsed, onToggle }: Props) => {
     <Box
       sx={{
         height: '100%',
-        bgcolor: s.bg,
+        bgcolor: s.background,
         color: s.text,
         display: 'flex',
         flexDirection: 'column',
@@ -125,7 +140,7 @@ export const Sidebar = ({ collapsed, onToggle }: Props) => {
             color: s.muted,
             borderRadius: '6px',
             bgcolor: 'rgba(255,255,255,0.05)',
-            '&:hover': { bgcolor: s.activeBg, color: s.text },
+            '&:hover': { bgcolor: s.activeBackground, color: s.text },
           }}
         >
           {collapsed ? (

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -1,15 +1,15 @@
-import { Box, IconButton, List, Typography } from '@mui/material'
-import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
-import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
-import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined'
-import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
-import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
+import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
-import { Link, useMatch } from 'react-router'
+import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined'
+import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
+import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import type { SvgIconComponent } from '@mui/icons-material'
-import { sidebarColors as c } from '@/app/styles/theme'
+import { Box, IconButton, List, Typography } from '@mui/material'
+import { useTheme } from '@mui/material/styles'
+import { Link, useMatch } from 'react-router'
 
 interface NavItemConfig {
   to: string
@@ -18,11 +18,11 @@ interface NavItemConfig {
 }
 
 const NAV_ITEMS: NavItemConfig[] = [
-  { to: '/profile',  icon: AccountCircleOutlinedIcon, label: 'Профиль' },
-  { to: '/library',  icon: AutoStoriesOutlinedIcon,   label: 'Библиотека' },
-  { to: '/feed',     icon: RssFeedOutlinedIcon,       label: 'Лента' },
-  { to: '/friends',  icon: PeopleOutlinedIcon,        label: 'Друзья' },
-  { to: '/search',   icon: SearchOutlinedIcon,        label: 'Поиск' },
+  { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
+  { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
+  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента' },
+  { to: '/friends', icon: PeopleOutlinedIcon, label: 'Друзья' },
+  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск' },
 ]
 
 const FOOTER_ITEMS: NavItemConfig[] = [
@@ -35,6 +35,8 @@ interface NavItemProps extends NavItemConfig {
 
 const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
   const isActive = !!useMatch(to)
+  const { palette } = useTheme()
+  const s = palette.sidebar
 
   return (
     <Box
@@ -48,13 +50,13 @@ const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
         py: '8px',
         borderRadius: '8px',
         textDecoration: 'none',
-        color: isActive ? c.text : c.muted,
-        bgcolor: isActive ? c.activeBg : 'transparent',
+        color: isActive ? s.text : s.muted,
+        bgcolor: isActive ? s.activeBg : 'transparent',
         justifyContent: collapsed ? 'center' : 'flex-start',
         cursor: 'pointer',
         flexShrink: 0,
         transition: 'background 0.15s, color 0.15s',
-        '&:hover': { bgcolor: c.activeBg, color: c.text },
+        '&:hover': { bgcolor: s.activeBg, color: s.text },
       }}
     >
       <Icon sx={{ fontSize: 22, flexShrink: 0 }} />
@@ -73,54 +75,100 @@ interface Props {
 }
 
 /**
- * Боковое меню приложения
+ * Боковое меню приложения.
  */
-export const Sidebar = ({ collapsed, onToggle }: Props) => (
-  <Box sx={{ height: '100%', bgcolor: c.bg, color: c.text, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
-    {/* Шапка: логотип + кнопка сворачивания */}
+export const Sidebar = ({ collapsed, onToggle }: Props) => {
+  const { palette } = useTheme()
+  const s = palette.sidebar
+
+  return (
     <Box
       sx={{
+        height: '100%',
+        bgcolor: s.bg,
+        color: s.text,
         display: 'flex',
-        alignItems: 'center',
-        justifyContent: collapsed ? 'center' : 'space-between',
-        px: 2,
-        pt: '18px',
-        pb: '14px',
-        borderBottom: `1px solid ${c.divider}`,
-        flexShrink: 0,
+        flexDirection: 'column',
+        overflow: 'hidden',
       }}
     >
-      {!collapsed && (
-        <Typography sx={{ fontSize: 17, fontWeight: 700, letterSpacing: '-0.02em', color: c.text, userSelect: 'none' }}>
-          Treqio
-        </Typography>
-      )}
-      <IconButton
-        onClick={onToggle}
-        size="small"
+      {/* Шапка: логотип + кнопка сворачивания */}
+      <Box
         sx={{
-          color: c.muted,
-          borderRadius: '6px',
-          bgcolor: 'rgba(255,255,255,0.05)',
-          '&:hover': { bgcolor: c.activeBg, color: c.text },
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: collapsed ? 'center' : 'space-between',
+          px: 2,
+          pt: '18px',
+          pb: '14px',
+          borderBottom: `1px solid ${s.divider}`,
+          flexShrink: 0,
         }}
       >
-        {collapsed ? <ChevronRightIcon sx={{ fontSize: 20 }} /> : <ChevronLeftIcon sx={{ fontSize: 20 }} />}
-      </IconButton>
-    </Box>
+        {!collapsed && (
+          <Typography
+            sx={{
+              fontSize: 17,
+              fontWeight: 700,
+              letterSpacing: '-0.02em',
+              color: s.text,
+              userSelect: 'none',
+            }}
+          >
+            Treqio
+          </Typography>
+        )}
+        <IconButton
+          onClick={onToggle}
+          size="small"
+          sx={{
+            color: s.muted,
+            borderRadius: '6px',
+            bgcolor: 'rgba(255,255,255,0.05)',
+            '&:hover': { bgcolor: s.activeBg, color: s.text },
+          }}
+        >
+          {collapsed ? (
+            <ChevronRightIcon sx={{ fontSize: 20 }} />
+          ) : (
+            <ChevronLeftIcon sx={{ fontSize: 20 }} />
+          )}
+        </IconButton>
+      </Box>
 
-    {/* Основная навигация */}
-    <Box sx={{ flex: 1, px: 1, py: '12px', display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'stretch' }}>
-      {NAV_ITEMS.map((item) => (
-        <NavItem key={item.to} {...item} collapsed={collapsed} />
-      ))}
-    </Box>
+      {/* Основная навигация */}
+      <Box
+        sx={{
+          flex: 1,
+          px: 1,
+          py: '12px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px',
+          alignItems: 'stretch',
+        }}
+      >
+        {NAV_ITEMS.map((item) => (
+          <NavItem key={item.to} {...item} collapsed={collapsed} />
+        ))}
+      </Box>
 
-    {/* Футер: настройки и профиль */}
-    <List disablePadding sx={{ px: 1, py: '12px', borderTop: `1px solid ${c.divider}`, display: 'flex', flexDirection: 'column', gap: '4px' }}>
-      {FOOTER_ITEMS.map((item) => (
-        <NavItem key={item.to} {...item} collapsed={collapsed} />
-      ))}
-    </List>
-  </Box>
-)
+      {/* Футер: настройки */}
+      <List
+        disablePadding
+        sx={{
+          px: 1,
+          py: '12px',
+          borderTop: `1px solid ${s.divider}`,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '4px',
+        }}
+      >
+        {FOOTER_ITEMS.map((item) => (
+          <NavItem key={item.to} {...item} collapsed={collapsed} />
+        ))}
+      </List>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary

- Module augmentation — расширен MUI Palette: добавлен `theme.palette.sidebar.*` с полной типизацией
- Четыре темы: Sage Library, Warm Latte, Slate, Dusty Plum — каждая описана токенами в `palettes`
- `buildTheme(variant)` — фабрика создаёт MUI тему для нужного варианта
- `themeSlice` (app/store) — хранит выбранный вариант в Redux + `localStorage`
- `ThemeProvider` — читает вариант из store, пересоздаёт тему при смене
- `Sidebar` — заменён импорт `sidebarColors` на `useTheme()`, убраны хардкод-цвета

## Test plan

- [ ] `npm run typecheck --workspace=@treqio/web` → без ошибок
- [ ] Приложение запускается, сайдбар отображается корректно