### PR TITLE
fix(web): указать tsconfigRootDir для ESLint в монорепо

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -18,6 +18,11 @@ export default tseslint.config(
       react: reactPlugin,
       'react-hooks': reactHooks,
     },
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     settings: {
       // Автоопределение версии React из package.json
       react: { version: 'detect' },


### PR DESCRIPTION
## Проблема

ESLint-парсер не мог определить какой `tsconfig.json` использовать — находил два кандидата в монорепо.

## Решение

Добавлен `tsconfigRootDir: import.meta.dirname` в `parserOptions` файла `apps/web/eslint.config.mjs`.