### PR TITLE
Добавление домашней страницы

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { CssBaseline, StyledEngineProvider, ThemeProvider as MuiThemeProvider } from '@mui/material'
 import type { ReactNode } from 'react'
 import { useAppSelector } from '@/shared/lib/store'
@@ -17,11 +17,11 @@ interface Props {
  */
 export const ThemeProvider = ({ children }: Props) => {
   const variant = useAppSelector((s) => s.theme.variant)
-  const theme = buildTheme(variant)
+  const theme = useMemo(() => buildTheme(variant), [variant])
 
   useEffect(() => {
     const root = document.documentElement
-    const { sidebar, primary, divider } = theme.palette
+    const { sidebar, primary, divider, text, background } = theme.palette
 
     // Токены сайдбара и hero-секций
     root.style.setProperty('--sidebar-bg', sidebar.background)
@@ -34,12 +34,22 @@ export const ThemeProvider = ({ children }: Props) => {
     root.style.setProperty('--color-primary-dark', primary.dark)
     root.style.setProperty('--color-divider', divider)
 
+    // Токены текста и поверхностей
+    root.style.setProperty('--color-text', text.primary)
+    root.style.setProperty('--color-text-2', text.secondary)
+    root.style.setProperty('--color-paper', background.paper)
+    root.style.setProperty('--color-paper-2', background.default)
+
+    // Токены чипов и плиток
+    root.style.setProperty('--color-chip-bg', primary.light + '33')
+    root.style.setProperty('--color-chip-text', primary.dark)
+
     // Токены кнопок на тёмном фоне сайдбара
     root.style.setProperty('--sidebar-btn-border', sidebar.activeBackground)
     root.style.setProperty('--sidebar-btn-outlined-border', 'rgba(255,255,255,.25)')
     root.style.setProperty('--sidebar-btn-disabled-border', 'rgba(255,255,255,.15)')
     root.style.setProperty('--sidebar-btn-disabled-color', 'rgba(255,255,255,.35)')
-  }, [theme])
+  }, [theme, variant])
 
   return (
     <StyledEngineProvider injectFirst>

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate, Outlet } from 'react-router'
 import { Box, CircularProgress } from '@mui/material'
 import { AuthCallbackPage } from '@/pages/auth-callback'
+import { HomePage } from '@/pages/home'
 import { LibraryPage } from '@/pages/library'
 import { LoginPage } from '@/pages/login'
 import { ProfilePage } from '@/pages/profile'
@@ -43,10 +44,10 @@ export const router = createBrowserRouter([
   {
     element: <RequireAuth />,
     children: [
-      { path: '/', element: <Navigate to="/library" replace /> },
       {
         element: <AppLayout />,
         children: [
+          { path: '/', element: <HomePage /> }, // Домашняя страница
           { path: '/library', element: <LibraryPage /> }, // Библиотека
           { path: '/profile', element: <ProfilePage /> }, // Профиль пользователя
         ],

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { authReducer } from '@/features/auth'
 import { baseApi } from '@/shared/api/baseApi'
 import themeReducer from './store/themeSlice'
+import layoutReducer from './store/layoutSlice'
 
 /**
  * Redux store приложения.
@@ -10,6 +11,7 @@ export const store = configureStore({
   reducer: {
     auth: authReducer,
     theme: themeReducer,
+    layout: layoutReducer,
     [baseApi.reducerPath]: baseApi.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(baseApi.middleware),

--- a/apps/web/src/app/store/layoutSlice.ts
+++ b/apps/web/src/app/store/layoutSlice.ts
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+const STORAGE_KEY = 'treqio_layout'
+
+/**
+ * Доступные виды представления домашней страницы.
+ */
+export type LayoutVariant = 'grid' | 'bento'
+
+/**
+ * Состояние вида представления домашней страницы.
+ */
+interface LayoutState {
+  /** Текущий вид: сетка или bento. */
+  variant: LayoutVariant
+}
+
+/** Начальное состояние — читаем из localStorage, иначе сетка. */
+const initialState: LayoutState = {
+  variant: (localStorage.getItem(STORAGE_KEY) as LayoutVariant | null) ?? 'grid',
+}
+
+/**
+ * Slice управления видом представления домашней страницы.
+ */
+const layoutSlice = createSlice({
+  name: 'layout',
+  initialState,
+  reducers: {
+    /**
+     * Смена вида представления. Сохраняет выбор в localStorage.
+     */
+    setLayout: (state, action: PayloadAction<LayoutVariant>) => {
+      state.variant = action.payload
+      localStorage.setItem(STORAGE_KEY, action.payload)
+    },
+  },
+})
+
+export const { setLayout } = layoutSlice.actions
+export default layoutSlice.reducer

--- a/apps/web/src/pages/home/HomePage.module.scss
+++ b/apps/web/src/pages/home/HomePage.module.scss
@@ -1,0 +1,546 @@
+$bp-sm: 600px;
+$bp-md: 900px;
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+// ─── Страница ─────────────────────────────────────────────────────────────────
+
+.home {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+// ─── Шапка ────────────────────────────────────────────────────────────────────
+
+.home__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 28px 36px 12px;
+  gap: 16px;
+
+  @media (max-width: $bp-sm) {
+    padding: 20px 20px 10px;
+  }
+}
+
+.home__title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text, inherit);
+  animation: rise 0.6s ease both;
+
+  @media (min-width: $bp-md) {
+    font-size: 30px;
+  }
+}
+
+// ─── Переключатель layout ─────────────────────────────────────────────────────
+
+.home__layout-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.home__layout-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+    color: var(--color-text, inherit);
+  }
+
+  &--active {
+    background: white;
+    color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  }
+}
+
+// ─── Лейбл секции ─────────────────────────────────────────────────────────────
+
+.home__label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 36px 8px;
+
+  @media (max-width: $bp-sm) {
+    padding: 0 20px 8px;
+  }
+}
+
+.home__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-2, #666);
+}
+
+// ─── Сетка (grid layout) ──────────────────────────────────────────────────────
+
+.grid {
+  padding: 0 36px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+
+  @media (max-width: $bp-sm) {
+    padding: 0 16px;
+    gap: 10px;
+  }
+}
+
+.grid__tile {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 22px 22px 20px;
+  min-height: 152px;
+
+  @media (max-width: $bp-sm) {
+    padding: 14px 14px 12px;
+    gap: 8px;
+    min-height: 120px;
+  }
+  background: white;
+  border: 1px solid var(--color-divider, #e0e0e0);
+  border-radius: 16px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  animation: rise 0.6s ease both;
+
+  &:nth-child(1) { animation-delay: 50ms; }
+  &:nth-child(2) { animation-delay: 100ms; }
+  &:nth-child(3) { animation-delay: 150ms; }
+  &:nth-child(4) { animation-delay: 200ms; }
+
+  // Градиентный блик снизу справа
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      120% 80% at 100% 100%,
+      color-mix(in oklab, var(--color-primary, #4e7b6a) 14%, transparent),
+      transparent 60%
+    );
+    opacity: 0;
+    transition: opacity 0.25s;
+    pointer-events: none;
+  }
+
+  &:hover {
+    border-color: var(--color-primary, #4e7b6a);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px -12px rgba(0, 0, 0, 0.15);
+
+    &::before { opacity: 1; }
+  }
+}
+
+.grid__tile-icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 11px;
+  background: var(--color-chip-bg, #dff0e5);
+  color: var(--color-chip-text, #3d6a55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  .grid__tile:hover & {
+    transform: rotate(-6deg) scale(1.05);
+  }
+
+  @media (max-width: $bp-sm) {
+    width: 34px;
+    height: 34px;
+    border-radius: 9px;
+  }
+}
+
+.grid__tile-title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--color-text, inherit);
+
+  @media (max-width: $bp-sm) {
+    font-size: 14px;
+  }
+}
+
+.grid__tile-desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-2, #666);
+
+  @media (max-width: $bp-sm) {
+    font-size: 11.5px;
+    line-height: 1.4;
+  }
+}
+
+.grid__tile-arrow {
+  position: absolute;
+  top: 22px;
+  right: 22px;
+  color: var(--color-text-2, #999);
+  transition: transform 0.2s, color 0.15s;
+
+  .grid__tile:hover & {
+    transform: translate(3px, -2px);
+    color: var(--color-primary, #4e7b6a);
+  }
+}
+
+// ─── Bento layout ─────────────────────────────────────────────────────────────
+
+.bento {
+  padding: 0 36px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  grid-auto-rows: 190px;
+  gap: 14px;
+
+  @media (max-width: $bp-md) {
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: auto;
+  }
+
+  @media (max-width: $bp-sm) {
+    padding: 0 16px;
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+    gap: 8px;
+  }
+}
+
+.bento__cell {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 22px;
+  background: white;
+  border: 1px solid var(--color-divider, #e0e0e0);
+  border-radius: 18px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  position: relative;
+  overflow: hidden;
+  transition: border-color 0.2s, transform 0.2s, box-shadow 0.2s;
+  animation: rise 0.6s ease both;
+
+  &:nth-child(1) { animation-delay: 40ms; }
+  &:nth-child(2) { animation-delay: 90ms; }
+  &:nth-child(3) { animation-delay: 140ms; }
+  &:nth-child(4) { animation-delay: 190ms; }
+
+  // Градиентный блик снизу справа
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(
+      120% 80% at 100% 100%,
+      color-mix(in oklab, var(--color-primary, #4e7b6a) 14%, transparent),
+      transparent 60%
+    );
+    opacity: 0;
+    transition: opacity 0.25s;
+    pointer-events: none;
+  }
+
+  &:hover {
+    border-color: var(--color-primary, #4e7b6a);
+    transform: translateY(-2px);
+    box-shadow: 0 10px 24px -12px rgba(0, 0, 0, 0.15);
+
+    &::before { opacity: 1; }
+  }
+
+  // Первая карточка — большая, занимает 2 строки только на десктопе
+  &--hero {
+    grid-column: 1;
+    grid-row: 1 / 3;
+
+    @media (max-width: $bp-md) {
+      grid-column: auto;
+      grid-row: auto;
+    }
+  }
+
+  @media (max-width: $bp-sm) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+    padding: 12px 14px;
+  }
+
+  // Тёмная карточка
+  &--dark {
+    background: var(--sidebar-bg, #243d35);
+    border-color: transparent;
+    color: var(--sidebar-text, #d8ebe4);
+
+    .bento__cell-desc {
+      color: var(--sidebar-muted, rgba(216, 235, 228, 0.6));
+    }
+
+    .bento__cell-icon {
+      color: var(--sidebar-text, #d8ebe4);
+    }
+  }
+}
+
+.bento__cell-content {
+  @media (max-width: $bp-sm) {
+    flex: 1;
+    min-width: 0;
+  }
+}
+
+.bento__cell-icon {
+  color: var(--color-primary, #4e7b6a);
+  flex-shrink: 0;
+  transition: transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  .bento__cell:hover & {
+    transform: rotate(-6deg) scale(1.05);
+  }
+}
+
+.bento__cell-title {
+  margin: 8px 0 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+
+  .bento__cell--hero & {
+    font-size: 26px;
+  }
+
+  @media (max-width: $bp-sm) {
+    font-size: 14px;
+    margin-top: 6px;
+
+    .bento__cell--hero & {
+      font-size: 14px;
+    }
+  }
+}
+
+.bento__cell-desc {
+  margin: 6px 0 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--color-text-2, #666);
+
+  @media (max-width: $bp-sm) {
+    font-size: 11.5px;
+    margin-top: 4px;
+  }
+}
+
+// ─── Обёртка grid + spacer + полоска ─────────────────────────────────────────
+
+.home__grid-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+// Растягивается чтобы занять свободное место, но всегда оставляет минимальный зазор
+.home__spacer {
+  flex: 1;
+  min-height: 14px;
+
+  @media (max-width: $bp-sm) {
+    min-height: 10px;
+  }
+}
+
+// ─── Bento — ячейка импорта и CTA ────────────────────────────────────────────
+
+.bento__cell--import {
+  cursor: not-allowed;
+  opacity: 0.7;
+
+  &:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: var(--color-divider, #e0e0e0);
+
+    &::before { opacity: 0; }
+
+    .bento__cell-icon {
+      transform: none;
+    }
+  }
+}
+
+.bento__cell-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 7px 14px;
+  border-radius: 999px;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+  font-size: 12px;
+  font-weight: 600;
+  align-self: flex-start;
+  pointer-events: none;
+  flex-shrink: 0;
+
+  @media (max-width: $bp-sm) {
+    align-self: center;
+    margin-left: auto;
+    padding: 6px;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--color-text-2, #666);
+  }
+}
+
+.bento__cell-cta-text {
+  @media (max-width: $bp-sm) {
+    display: none;
+  }
+}
+
+// ─── Полоска импорта ──────────────────────────────────────────────────────────
+
+.import-strip {
+  margin: 0 36px 32px;
+  padding: 10px 20px;
+  background: white;
+  border: 1px solid var(--color-divider, #e0e0e0);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+  animation: rise 0.6s ease 0.25s both;
+
+  // Шиммер в цвет основного акцента темы
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      90deg,
+      transparent,
+      color-mix(in oklab, var(--color-primary, #4e7b6a) 20%, transparent),
+      transparent
+    );
+    transform: translateX(-100%);
+    transition: transform 1s ease;
+    pointer-events: none;
+  }
+
+  &:hover::after {
+    transform: translateX(100%);
+  }
+
+  @media (max-width: $bp-sm) {
+    margin: 0 16px 24px;
+  }
+}
+
+.import-strip__left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.import-strip__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--color-chip-bg, #dff0e5);
+  color: var(--color-chip-text, #3d6a55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.import-strip__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text, inherit);
+}
+
+.import-strip__sub {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: var(--color-text-2, #666);
+}
+
+.import-strip__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 18px;
+  border: none;
+  border-radius: 10px;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: not-allowed;
+  opacity: 0.6;
+  flex-shrink: 0;
+
+  @media (max-width: $bp-sm) {
+    padding: 8px;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--color-text-2, #666);
+    opacity: 1;
+  }
+}
+
+.import-strip__btn-text {
+  @media (max-width: $bp-sm) {
+    display: none;
+  }
+}

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -1,0 +1,210 @@
+import { BookOpen, Gamepad2, LayoutGrid, Palette, PanelTop, User } from 'lucide-react'
+import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
+import { setLayout } from '@/app/store/layoutSlice'
+import type { LayoutVariant } from '@/app/store/layoutSlice'
+import styles from './HomePage.module.scss'
+
+/**
+ * Плитки быстрых действий.
+ */
+const TILES = [
+  {
+    icon: <BookOpen size={22} />,
+    title: 'Найти книгу',
+    desc: 'Добавить в список, отметить прочитанной, поставить оценку.',
+    href: '/library',
+  },
+  {
+    icon: <Gamepad2 size={22} />,
+    title: 'Найти игру',
+    desc: 'Добавить в список, отметить пройденной, поставить оценку.',
+    href: '/library',
+  },
+  {
+    icon: <User size={22} />,
+    title: 'Настроить профиль',
+    desc: 'Имя, аватар, видимость и приватность.',
+    href: '/profile',
+  },
+  {
+    icon: <Palette size={22} />,
+    title: 'Настроить тему',
+    desc: 'Цветовая палитра и шрифт интерфейса.',
+    href: '/settings',
+  },
+]
+
+/**
+ * Иконка стрелки для плитки.
+ */
+function ArrowIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M5 12h14M13 5l7 7-7 7" />
+    </svg>
+  )
+}
+
+/**
+ * Домашняя страница — точка входа для авторизованного пользователя.
+ */
+export function HomePage() {
+  const dispatch = useAppDispatch()
+  const layout = useAppSelector((s) => s.layout.variant)
+
+  const handleLayoutChange = (variant: LayoutVariant) => {
+    dispatch(setLayout(variant))
+  }
+
+  return (
+    <div className={styles['home']}>
+      <div className={styles['home__header']}>
+        <h1 className={styles['home__title']}>Чем сегодня займёмся?</h1>
+      </div>
+
+      <div className={styles['home__label-row']}>
+        <span className={styles['home__label']}>Быстрые действия</span>
+
+        {/* Переключатель вида */}
+        <div className={styles['home__layout-toggle']}>
+          <button
+            className={`${styles['home__layout-btn']} ${layout === 'grid' ? styles['home__layout-btn--active'] : ''}`}
+            onClick={() => handleLayoutChange('grid')}
+            title="Сетка"
+          >
+            <LayoutGrid size={16} />
+          </button>
+          <button
+            className={`${styles['home__layout-btn']} ${layout === 'bento' ? styles['home__layout-btn--active'] : ''}`}
+            onClick={() => handleLayoutChange('bento')}
+            title="Bento"
+          >
+            <PanelTop size={16} />
+          </button>
+        </div>
+      </div>
+
+      {layout === 'grid' ? (
+        <div className={styles['home__grid-section']}>
+          <GridLayout />
+          <div className={styles['home__spacer']} />
+          <ImportStrip />
+        </div>
+      ) : (
+        <BentoLayout />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Сетка 2×2.
+ */
+function GridLayout() {
+  return (
+    <div className={styles['grid']}>
+      {TILES.map((tile) => (
+        <button key={tile.title} className={styles['grid__tile']}>
+          <div className={styles['grid__tile-icon']}>{tile.icon}</div>
+          <div>
+            <p className={styles['grid__tile-title']}>{tile.title}</p>
+            <p className={styles['grid__tile-desc']}>{tile.desc}</p>
+          </div>
+          <span className={styles['grid__tile-arrow']}>
+            <ArrowIcon />
+          </span>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Bento-раскладка.
+ */
+function BentoLayout() {
+  const [books, games, profile, theme] = TILES
+
+  return (
+    <div className={styles['bento']}>
+      <button className={`${styles['bento__cell']} ${styles['bento__cell--hero']}`}>
+        <div className={styles['bento__cell-icon']}>{books.icon}</div>
+        <div className={styles['bento__cell-content']}>
+          <p className={styles['bento__cell-title']}>{books.title}</p>
+          <p className={styles['bento__cell-desc']}>{books.desc}</p>
+        </div>
+      </button>
+
+      <button className={`${styles['bento__cell']} ${styles['bento__cell--dark']}`}>
+        <div className={styles['bento__cell-icon']}>{games.icon}</div>
+        <div className={styles['bento__cell-content']}>
+          <p className={styles['bento__cell-title']}>{games.title}</p>
+          <p className={styles['bento__cell-desc']}>{games.desc}</p>
+        </div>
+      </button>
+
+      <button className={styles['bento__cell']}>
+        <div className={styles['bento__cell-icon']}>{profile.icon}</div>
+        <div className={styles['bento__cell-content']}>
+          <p className={styles['bento__cell-title']}>{profile.title}</p>
+          <p className={styles['bento__cell-desc']}>{profile.desc}</p>
+        </div>
+      </button>
+
+      <button className={styles['bento__cell']}>
+        <div className={styles['bento__cell-icon']}>{theme.icon}</div>
+        <div className={styles['bento__cell-content']}>
+          <p className={styles['bento__cell-title']}>{theme.title}</p>
+          <p className={styles['bento__cell-desc']}>{theme.desc}</p>
+        </div>
+      </button>
+
+      {/* Импорт как пятая ячейка bento */}
+      <button className={`${styles['bento__cell']} ${styles['bento__cell--import']}`} disabled>
+        <div className={styles['bento__cell-icon']}>
+          <BookOpen size={22} />
+        </div>
+        <div className={styles['bento__cell-content']}>
+          <p className={styles['bento__cell-title']}>Импорт</p>
+          <p className={styles['bento__cell-desc']}>Goodreads, HLTB — скоро</p>
+        </div>
+        <span className={styles['bento__cell-cta']}>
+          <span className={styles['bento__cell-cta-text']}>Подключить</span>
+          <ArrowIcon />
+        </span>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * Заглушка полоски импорта из внешних сервисов.
+ */
+function ImportStrip() {
+  return (
+    <div className={styles['import-strip']}>
+      <div className={styles['import-strip__left']}>
+        <div className={styles['import-strip__icon']}>
+          <BookOpen size={18} />
+        </div>
+        <div>
+          <p className={styles['import-strip__title']}>Импортировать списки</p>
+          <p className={styles['import-strip__sub']}>Goodreads, HLTB — скоро</p>
+        </div>
+      </div>
+      <button className={styles['import-strip__btn']} disabled>
+        <span className={styles['import-strip__btn-text']}>Подключить</span>
+        <ArrowIcon />
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/pages/home/index.ts
+++ b/apps/web/src/pages/home/index.ts
@@ -1,0 +1,1 @@
+export { HomePage } from './HomePage'

--- a/apps/web/src/widgets/layout/MobileNav.tsx
+++ b/apps/web/src/widgets/layout/MobileNav.tsx
@@ -1,18 +1,18 @@
 import { Box, Paper } from '@mui/material'
-import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
-import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
-import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined'
-import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined'
+import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
+import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
+import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import { useNavigate, useLocation } from 'react-router'
 import type { SvgIconComponent } from '@mui/icons-material'
 
 const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string }[] = [
-  { to: '/profile',  icon: AccountCircleOutlinedIcon, label: 'Профиль' },
-  { to: '/library',  icon: AutoStoriesOutlinedIcon,   label: 'Библиотека' },
-  { to: '/feed',     icon: RssFeedOutlinedIcon,       label: 'Лента' },
-  { to: '/friends',  icon: PeopleOutlinedIcon,        label: 'Друзья' },
-  { to: '/search',   icon: SearchOutlinedIcon,        label: 'Поиск' },
+  { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
+  { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
+  { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
+  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента' },
+  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск' },
 ]
 
 /**
@@ -37,7 +37,8 @@ export const MobileNav = () => {
     >
       <Box sx={{ display: 'flex', height: 56, bgcolor: 'background.paper' }}>
         {NAV_ITEMS.map(({ to, icon: Icon, label }) => {
-          const isActive = pathname.startsWith(to)
+          // Для "/" нужно точное совпадение, иначе будет активен на всех страницах
+          const isActive = to === '/' ? pathname === '/' : pathname.startsWith(to)
           return (
             <Box
               key={to}

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -2,6 +2,7 @@ import AccountCircleOutlinedIcon from '@mui/icons-material/AccountCircleOutlined
 import AutoStoriesOutlinedIcon from '@mui/icons-material/AutoStoriesOutlined'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
 import ChevronRightIcon from '@mui/icons-material/ChevronRight'
+import HomeOutlinedIcon from '@mui/icons-material/HomeOutlined'
 import PeopleOutlinedIcon from '@mui/icons-material/PeopleOutlined'
 import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
@@ -27,6 +28,7 @@ interface NavItemConfig {
  * Основные пункты навигации.
  */
 const NAV_ITEMS: NavItemConfig[] = [
+  { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
   { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
   { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
   { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента' },


### PR DESCRIPTION
## Что сделано

- Роут `/` — домашняя страница для авторизованных пользователей
- Два вида представления: **Сетка** и **Bento**, переключатель сохраняется в localStorage
- 4 плитки быстрых действий: Найти книгу, Найти игру, Профиль, Тема
- Полоска импорта (Goodreads, HLTB) — статическая заглушка
- Hover-эффекты: наклон иконки, градиент снизу-справа, шиммер на полоске импорта
- Адаптив: сетка 2×2 на мобилке, bento — горизонтальные полоски
- Пункт **Главная** добавлен в сайдбар и мобильную навигацию
- `layoutSlice` — Redux + localStorage для хранения выбранного вида

## Как проверить

1. Войти через Google
2. Убедиться что сразу открывается домашняя страница (не белый экран)
3. Переключить сетка ↔ bento, обновить — выбор сохраняется
4. Проверить мобилку: оба вида, полоска импорта