### PR TITLE
Страница настроек с выбором темы

### DIFF
--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -5,6 +5,7 @@ import { HomePage } from '@/pages/home'
 import { LibraryPage } from '@/pages/library'
 import { LoginPage } from '@/pages/login'
 import { ProfilePage } from '@/pages/profile'
+import { SettingsPage } from '@/pages/settings'
 import { useAppSelector } from '@/shared/lib/store'
 import { AppLayout } from '@/widgets/layout'
 
@@ -50,6 +51,7 @@ export const router = createBrowserRouter([
           { path: '/', element: <HomePage /> }, // Домашняя страница
           { path: '/library', element: <LibraryPage /> }, // Библиотека
           { path: '/profile', element: <ProfilePage /> }, // Профиль пользователя
+          { path: '/settings', element: <SettingsPage /> }, // Настройки
         ],
       },
     ],

--- a/apps/web/src/app/styles/theme.ts
+++ b/apps/web/src/app/styles/theme.ts
@@ -1,5 +1,5 @@
 import { createTheme } from '@mui/material/styles'
-import type { PaletteOptions } from '@mui/material/styles'
+import type { PaletteOptions, SimplePaletteColorOptions } from '@mui/material/styles'
 
 declare module '@mui/material/styles' {
   /**
@@ -172,3 +172,27 @@ export function buildTheme(variant: ThemeVariant) {
 
 /** Дефолтная тема приложения. */
 export const DEFAULT_THEME: ThemeVariant = 'sageLibrary'
+
+/**
+ * Отображаемые названия вариантов темы.
+ */
+const THEME_NAMES: Record<ThemeVariant, string> = {
+  sageLibrary: 'Sage Library',
+  warmLatte: 'Warm Latte',
+  slate: 'Slate',
+  dustyPlum: 'Dusty Plum',
+}
+
+/**
+ * Метаданные тем для UI выбора темы — цвета берутся из palettes.
+ */
+export const THEMES_META = (Object.keys(palettes) as ThemeVariant[]).map((variant) => {
+  const p = palettes[variant]
+  return {
+    variant,
+    name: THEME_NAMES[variant],
+    sidebarColor: p.sidebar!.background!,
+    primaryColor: (p.primary as SimplePaletteColorOptions).main,
+    bgColor: p.background!.default!,
+  }
+})

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -1,4 +1,5 @@
 import { BookOpen, Gamepad2, LayoutGrid, Palette, PanelTop, User } from 'lucide-react'
+import { useNavigate } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import { setLayout } from '@/app/store/layoutSlice'
 import type { LayoutVariant } from '@/app/store/layoutSlice'
@@ -110,10 +111,16 @@ export function HomePage() {
  * Сетка 2×2.
  */
 function GridLayout() {
+  const navigate = useNavigate()
+
   return (
     <div className={styles['grid']}>
       {TILES.map((tile) => (
-        <button key={tile.title} className={styles['grid__tile']}>
+        <button
+          key={tile.title}
+          className={styles['grid__tile']}
+          onClick={() => navigate(tile.href)}
+        >
           <div className={styles['grid__tile-icon']}>{tile.icon}</div>
           <div>
             <p className={styles['grid__tile-title']}>{tile.title}</p>
@@ -132,11 +139,18 @@ function GridLayout() {
  * Bento-раскладка.
  */
 function BentoLayout() {
-  const [books, games, profile, theme] = TILES
+  const navigate = useNavigate()
+  const books = TILES[0]!
+  const games = TILES[1]!
+  const profile = TILES[2]!
+  const theme = TILES[3]!
 
   return (
     <div className={styles['bento']}>
-      <button className={`${styles['bento__cell']} ${styles['bento__cell--hero']}`}>
+      <button
+        className={`${styles['bento__cell']} ${styles['bento__cell--hero']}`}
+        onClick={() => navigate(books.href)}
+      >
         <div className={styles['bento__cell-icon']}>{books.icon}</div>
         <div className={styles['bento__cell-content']}>
           <p className={styles['bento__cell-title']}>{books.title}</p>
@@ -144,7 +158,10 @@ function BentoLayout() {
         </div>
       </button>
 
-      <button className={`${styles['bento__cell']} ${styles['bento__cell--dark']}`}>
+      <button
+        className={`${styles['bento__cell']} ${styles['bento__cell--dark']}`}
+        onClick={() => navigate(games.href)}
+      >
         <div className={styles['bento__cell-icon']}>{games.icon}</div>
         <div className={styles['bento__cell-content']}>
           <p className={styles['bento__cell-title']}>{games.title}</p>
@@ -152,7 +169,7 @@ function BentoLayout() {
         </div>
       </button>
 
-      <button className={styles['bento__cell']}>
+      <button className={styles['bento__cell']} onClick={() => navigate(profile.href)}>
         <div className={styles['bento__cell-icon']}>{profile.icon}</div>
         <div className={styles['bento__cell-content']}>
           <p className={styles['bento__cell-title']}>{profile.title}</p>
@@ -160,7 +177,7 @@ function BentoLayout() {
         </div>
       </button>
 
-      <button className={styles['bento__cell']}>
+      <button className={styles['bento__cell']} onClick={() => navigate(theme.href)}>
         <div className={styles['bento__cell-icon']}>{theme.icon}</div>
         <div className={styles['bento__cell-content']}>
           <p className={styles['bento__cell-title']}>{theme.title}</p>

--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -1,0 +1,319 @@
+$bp-sm: 600px;
+$bp-md: 900px;
+
+@keyframes spin-slow {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes slide-in {
+  from { opacity: 0; transform: translateX(12px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+
+// ─── Страница ─────────────────────────────────────────────────────────────────
+
+.settings {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+.settings__header {
+  padding: 12px 36px 10px;
+  flex-shrink: 0;
+  background: var(--color-chip-bg, #dff0e5);
+  border-bottom: 1px solid var(--color-divider, #e0e0e0);
+
+  @media (max-width: $bp-sm) {
+    padding: 10px 20px 8px;
+  }
+}
+
+.settings__title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--sidebar-bg, #243d35);
+  animation: rise 0.6s ease both;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.settings__title-icon {
+  color: var(--color-text-2, #666);
+  flex-shrink: 0;
+  margin-right: -2px;
+}
+
+// ─── Тело страницы — список + контент ─────────────────────────────────────────
+
+.settings__body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: 0;
+
+  @media (min-width: $bp-md) {
+    gap: 0;
+  }
+}
+
+// ─── Список разделов ──────────────────────────────────────────────────────────
+
+.settings__nav {
+  flex-shrink: 0;
+  padding: 0 16px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  animation: rise 0.6s ease 0.1s both;
+
+  // На мобилке — прячем список если открыт раздел
+  @media (max-width: $bp-md) {
+    width: 100%;
+    padding: 0 20px 24px;
+
+    &--hidden {
+      display: none;
+    }
+  }
+
+  @media (min-width: $bp-md) {
+    width: 280px;
+    padding: 12px 16px 24px;
+    background: var(--color-paper, white);
+    border-right: 1px solid var(--color-divider, #e0e0e0);
+  }
+}
+
+.settings__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 11px 14px;
+  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--color-text, inherit);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--color-paper-2, rgba(0, 0, 0, 0.05));
+  }
+
+  &--active {
+    background: var(--color-chip-bg, #dff0e5);
+    color: var(--color-primary, #4e7b6a);
+    font-weight: 600;
+  }
+}
+
+.settings__nav-icon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: var(--color-chip-bg, #dff0e5);
+  color: var(--color-chip-text, #3d6a55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.settings__nav-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings__nav-label {
+  display: block;
+}
+
+.settings__nav-desc {
+  display: block;
+  font-size: 12px;
+  font-weight: 400;
+  color: var(--color-text-2, #666);
+  margin-top: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings__nav-chevron {
+  color: var(--color-text-2, #999);
+  flex-shrink: 0;
+
+  // На десктопе стрелку не показываем
+  @media (min-width: $bp-md) {
+    display: none;
+  }
+}
+
+// ─── Контент раздела ──────────────────────────────────────────────────────────
+
+.settings__content {
+  flex: 1;
+  min-width: 0;
+  background: var(--color-paper-2, #f5f5f5);
+  animation: slide-in 0.25s ease both;
+
+  // На мобилке — прячем если нет выбранного раздела
+  @media (max-width: $bp-md) {
+    &--hidden {
+      display: none;
+    }
+  }
+}
+
+// Кнопка «Назад» — только мобилка
+.settings__back {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 20px 8px;
+  border: none;
+  background: transparent;
+  color: var(--color-primary, #4e7b6a);
+  font-family: inherit;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+
+  @media (min-width: $bp-md) {
+    display: none;
+  }
+}
+
+.settings__section {
+  padding: 20px 28px 32px;
+
+  @media (max-width: $bp-sm) {
+    padding: 16px 20px 24px;
+  }
+}
+
+.settings__section-title {
+  margin: 0 0 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-2, #666);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+// ─── Сетка тем ────────────────────────────────────────────────────────────────
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+
+  @media (min-width: $bp-sm) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+// ─── Карточка темы ────────────────────────────────────────────────────────────
+
+.theme-card {
+  border: 2px solid var(--color-divider, #e0e0e0);
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  font-family: inherit;
+  background: none;
+  padding: 0;
+  text-align: left;
+  transition: border-color 0.2s, transform 0.15s, box-shadow 0.2s;
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px -8px rgba(0, 0, 0, 0.15);
+  }
+
+  &--active {
+    border-color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 0 0 1px var(--color-primary, #4e7b6a);
+  }
+}
+
+.theme-card__preview {
+  display: flex;
+  height: 72px;
+  position: relative;
+}
+
+.theme-card__sidebar {
+  width: 28%;
+  flex-shrink: 0;
+}
+
+.theme-card__content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 8px 10px;
+  gap: 5px;
+}
+
+.theme-card__dot {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+}
+
+.theme-card__line {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--color-divider, #e0e0e0);
+  opacity: 0.6;
+
+  &--wide { width: 70%; }
+  &--narrow { width: 45%; }
+}
+
+.theme-card__check {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.theme-card__footer {
+  padding: 8px 10px;
+  border-top: 1px solid var(--color-divider, #e0e0e0);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text, inherit);
+  background: white;
+}
+
+.theme-card--active .theme-card__footer {
+  color: var(--color-primary, #4e7b6a);
+  font-weight: 600;
+}

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react'
+import { ChevronLeft, ChevronRight, Check, Palette, Settings } from 'lucide-react'
+import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
+import { setTheme } from '@/app/store/themeSlice'
+import { THEMES_META } from '@/app/styles/theme'
+import type { ThemeVariant } from '@/app/styles/theme'
+import styles from './SettingsPage.module.scss'
+
+/**
+ * Раздел настроек.
+ */
+interface SettingsSection {
+  /** Идентификатор раздела. */
+  id: string
+  /** Название раздела. */
+  label: string
+  /** Краткое описание. */
+  desc: string
+  /** Иконка раздела. */
+  icon: React.ReactNode
+  /** Содержимое раздела. */
+  content: React.ReactNode
+}
+
+/**
+ * Страница настроек приложения.
+ */
+export function SettingsPage() {
+  const [activeSection, setActiveSection] = useState<string | null>(null)
+
+  const sections: SettingsSection[] = [
+    {
+      id: 'appearance',
+      label: 'Внешний вид',
+      desc: 'Тема оформления',
+      icon: <Palette size={18} />,
+      content: <AppearanceContent />,
+    },
+  ]
+
+  const active = sections.find((s) => s.id === activeSection)
+
+  return (
+    <div className={styles['settings']}>
+      <div className={styles['settings__header']}>
+        <h1 className={styles['settings__title']}>
+          Настройки
+          <Settings size={28} className={styles['settings__title-icon']} />
+        </h1>
+      </div>
+
+      <div className={styles['settings__body']}>
+        {/* Список разделов */}
+        <nav
+          className={`${styles['settings__nav']} ${active ? styles['settings__nav--hidden'] : ''}`}
+        >
+          {sections.map((section) => (
+            <button
+              key={section.id}
+              className={`${styles['settings__nav-item']} ${activeSection === section.id ? styles['settings__nav-item--active'] : ''}`}
+              onClick={() => setActiveSection(section.id)}
+            >
+              <div className={styles['settings__nav-icon']}>{section.icon}</div>
+              <div className={styles['settings__nav-info']}>
+                <span className={styles['settings__nav-label']}>{section.label}</span>
+                <span className={styles['settings__nav-desc']}>{section.desc}</span>
+              </div>
+              <ChevronRight size={16} className={styles['settings__nav-chevron']} />
+            </button>
+          ))}
+        </nav>
+
+        {/* Контент выбранного раздела */}
+        {active && (
+          <div className={styles['settings__content']}>
+            <button className={styles['settings__back']} onClick={() => setActiveSection(null)}>
+              <ChevronLeft size={16} />
+              Назад
+            </button>
+            <div className={styles['settings__section']}>
+              <p className={styles['settings__section-title']}>{active.label}</p>
+              {active.content}
+            </div>
+          </div>
+        )}
+
+        {/* На десктопе — показываем контент сразу при выборе из списка */}
+        {!active && (
+          <div
+            className={`${styles['settings__content']} ${styles['settings__content--hidden']}`}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Содержимое раздела «Внешний вид».
+ */
+function AppearanceContent() {
+  const dispatch = useAppDispatch()
+  const activeVariant = useAppSelector((s) => s.theme.variant)
+
+  const handleSelect = (variant: ThemeVariant) => {
+    dispatch(setTheme(variant))
+  }
+
+  return (
+    <div className={styles['theme-grid']}>
+      {THEMES_META.map((theme) => (
+        <ThemeCard
+          key={theme.variant}
+          theme={theme}
+          isActive={theme.variant === activeVariant}
+          onSelect={handleSelect}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Свойства карточки темы.
+ */
+interface ThemeCardProps {
+  /** Метаданные темы. */
+  theme: (typeof THEMES_META)[number]
+  /** Флаг активной темы. */
+  isActive: boolean
+  /** Функция выбора темы. */
+  onSelect: (variant: ThemeVariant) => void
+}
+
+/**
+ * Карточка выбора темы с визуальным превью цветов.
+ */
+function ThemeCard({ theme, isActive, onSelect }: ThemeCardProps) {
+  return (
+    <button
+      className={`${styles['theme-card']} ${isActive ? styles['theme-card--active'] : ''}`}
+      onClick={() => onSelect(theme.variant)}
+    >
+      <div className={styles['theme-card__preview']}>
+        <div className={styles['theme-card__sidebar']} style={{ background: theme.sidebarColor }} />
+        <div className={styles['theme-card__content']} style={{ background: theme.bgColor }}>
+          <div className={styles['theme-card__dot']} style={{ background: theme.primaryColor }} />
+          <div className={`${styles['theme-card__line']} ${styles['theme-card__line--wide']}`} />
+          <div className={`${styles['theme-card__line']} ${styles['theme-card__line--narrow']}`} />
+        </div>
+        {isActive && (
+          <span className={styles['theme-card__check']}>
+            <Check size={12} strokeWidth={3} />
+          </span>
+        )}
+      </div>
+      <div className={styles['theme-card__footer']}>{theme.name}</div>
+    </button>
+  )
+}

--- a/apps/web/src/pages/settings/index.ts
+++ b/apps/web/src/pages/settings/index.ts
@@ -1,0 +1,1 @@
+export { SettingsPage } from './SettingsPage'


### PR DESCRIPTION
## Что сделано

- Страница `/settings` с боковым меню разделов (drill-down на мобилке, split-view на десктопе)
- Раздел «Внешний вид» — карточки-превью всех тем с цветами палитры
- Активная тема подсвечена рамкой и чекмарком
- `THEMES_META` выводится из `palettes` без дублирования цветов
- Плитки на домашней странице стали кликабельными (navigate)
- Роут `/settings` добавлен в роутер