### PR TITLE
feat(web): темы, анимации и улучшения домашней страницы

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from 'react'
 import { CssBaseline, StyledEngineProvider, ThemeProvider as MuiThemeProvider } from '@mui/material'
 import type { ReactNode } from 'react'
 import { useAppSelector } from '@/shared/lib/store'
+import { THEME_COLORS } from '@/shared/config/themes'
 import { buildTheme } from '../styles/theme'
 
 /**
@@ -43,6 +44,14 @@ export const ThemeProvider = ({ children }: Props) => {
     // Токены чипов и плиток
     root.style.setProperty('--color-chip-bg', primary.light + '33')
     root.style.setProperty('--color-chip-text', primary.dark)
+
+    // Цвет заголовков на тематическом фоне — тёмный для светлых тем, светлый для тёмных
+    const isDark = THEME_COLORS[variant].isDark ?? false
+    root.style.setProperty('--header-title-color', isDark ? sidebar.text : sidebar.background)
+
+    // Акцентная поверхность для тёмных блоков (bento dark cell и т.п.)
+    const surfaceVariant = THEME_COLORS[variant].surfaceVariant ?? sidebar.background
+    root.style.setProperty('--color-surface-variant', surfaceVariant)
 
     // Токены кнопок на тёмном фоне сайдбара
     root.style.setProperty('--sidebar-btn-border', sidebar.activeBackground)

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -52,6 +52,7 @@ export const router = createBrowserRouter([
           { path: '/library', element: <LibraryPage /> }, // Библиотека
           { path: '/profile', element: <ProfilePage /> }, // Профиль пользователя
           { path: '/settings', element: <SettingsPage /> }, // Настройки
+          { path: '/settings/:section', element: <SettingsPage /> }, // Раздел настроек
         ],
       },
     ],

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -2,6 +2,7 @@ import { configureStore } from '@reduxjs/toolkit'
 import { authReducer } from '@/features/auth'
 import { themeReducer } from '@/features/theme'
 import { layoutReducer } from '@/features/layout'
+import { animationsReducer } from '@/features/animations'
 import { baseApi } from '@/shared/api/baseApi'
 
 /**
@@ -12,6 +13,7 @@ export const store = configureStore({
     auth: authReducer,
     theme: themeReducer,
     layout: layoutReducer,
+    animations: animationsReducer,
     [baseApi.reducerPath]: baseApi.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(baseApi.middleware),

--- a/apps/web/src/app/styles/theme.ts
+++ b/apps/web/src/app/styles/theme.ts
@@ -80,9 +80,11 @@ const palettes = Object.fromEntries(
  * Создаёт MUI тему для заданного варианта палитры.
  */
 export function buildTheme(variant: ThemeVariant) {
+  const isDark = THEME_COLORS[variant].isDark ?? false
+
   return createTheme({
     palette: {
-      mode: 'light',
+      mode: isDark ? 'dark' : 'light',
       ...palettes[variant],
       error: { main: '#B94040' },
       warning: { main: '#C49A3A' },

--- a/apps/web/src/features/animations/index.ts
+++ b/apps/web/src/features/animations/index.ts
@@ -1,0 +1,6 @@
+export {
+  default as animationsReducer,
+  toggleParticles,
+  setParticles,
+} from './model/animationsSlice'
+export { ParticleCanvas } from './ui/ParticleCanvas'

--- a/apps/web/src/features/animations/model/animationsSlice.ts
+++ b/apps/web/src/features/animations/model/animationsSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+const STORAGE_KEY = 'treqio_animations'
+
+/**
+ * Состояние анимаций приложения.
+ */
+interface AnimationsState {
+  /** Флаг включённых частиц на главной странице. */
+  particlesEnabled: boolean
+}
+
+const initialState: AnimationsState = {
+  particlesEnabled: localStorage.getItem(STORAGE_KEY) === 'true',
+}
+
+/**
+ * Slice управления анимациями приложения.
+ */
+const animationsSlice = createSlice({
+  name: 'animations',
+  initialState,
+  reducers: {
+    /**
+     * Переключение анимации частиц. Сохраняет выбор в localStorage.
+     */
+    toggleParticles: (state) => {
+      state.particlesEnabled = !state.particlesEnabled
+      localStorage.setItem(STORAGE_KEY, String(state.particlesEnabled))
+    },
+    setParticles: (state, action: PayloadAction<boolean>) => {
+      state.particlesEnabled = action.payload
+      localStorage.setItem(STORAGE_KEY, String(action.payload))
+    },
+  },
+})
+
+export const { toggleParticles, setParticles } = animationsSlice.actions
+export default animationsSlice.reducer

--- a/apps/web/src/features/animations/ui/ParticleCanvas.tsx
+++ b/apps/web/src/features/animations/ui/ParticleCanvas.tsx
@@ -1,0 +1,241 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Доступные типы анимации частиц.
+ */
+type ParticleType = 'leaf' | 'dust' | 'dot' | 'ember'
+
+/**
+ * Состояние одной частицы в анимации.
+ */
+interface Particle {
+  /** Позиция по X. */
+  x: number
+  /** Позиция по Y. */
+  y: number
+  /** Скорость по вертикали (отрицательная у ember — движение вверх). */
+  vy: number
+  /** Скорость по горизонтали. */
+  vx: number
+  /** Текущий угол поворота (радианы). */
+  rot: number
+  /** Скорость вращения. */
+  vrot: number
+  /** Фаза горизонтального покачивания. */
+  sway: number
+  /** Скорость изменения фазы покачивания. */
+  swaySpeed: number
+  /** Размер частицы. */
+  size: number
+  /** Прозрачность. */
+  opacity: number
+}
+
+/**
+ * Создаёт частицу со случайными параметрами.
+ * Ember стартует снизу и движется вверх; остальные — сверху вниз.
+ */
+function makeParticle(
+  width: number,
+  height: number,
+  type: ParticleType,
+  randomY = false,
+): Particle {
+  const isEmber = type === 'ember'
+  return {
+    x: Math.random() * width,
+    y: randomY
+      ? Math.random() * height
+      : isEmber
+        ? height + 20 + Math.random() * 60
+        : -20 - Math.random() * height * 0.5,
+    vy: isEmber ? -(0.15 + Math.random() * 0.3) : 0.12 + Math.random() * 0.25,
+    vx: -0.15 + Math.random() * 0.3,
+    rot: Math.random() * Math.PI * 2,
+    vrot: -0.008 + Math.random() * 0.016,
+    sway: Math.random() * Math.PI * 2,
+    swaySpeed: 0.004 + Math.random() * 0.008,
+    size: type === 'dot' || type === 'dust' ? 2 + Math.random() * 3 : 6 + Math.random() * 10,
+    opacity: type === 'ember' ? 0.4 + Math.random() * 0.4 : 0.18 + Math.random() * 0.35,
+  }
+}
+
+/**
+ * Читает основной цвет активной темы из CSS-переменной.
+ */
+function getColor(): string {
+  return (
+    getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim() ||
+    '#4E7B6A'
+  )
+}
+
+/**
+ * Рисует лист — миндалевидная форма с центральной жилкой.
+ */
+function drawLeaf(ctx: CanvasRenderingContext2D, p: Particle) {
+  const color = getColor()
+  ctx.save()
+  ctx.translate(p.x, p.y)
+  ctx.rotate(p.rot)
+  ctx.globalAlpha = p.opacity
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.moveTo(0, -p.size)
+  ctx.bezierCurveTo(p.size * 0.7, -p.size * 0.5, p.size * 0.7, p.size * 0.5, 0, p.size)
+  ctx.bezierCurveTo(-p.size * 0.7, p.size * 0.5, -p.size * 0.7, -p.size * 0.5, 0, -p.size)
+  ctx.fill()
+  ctx.globalAlpha = p.opacity * 0.4
+  ctx.strokeStyle = '#fff'
+  ctx.lineWidth = 0.8
+  ctx.beginPath()
+  ctx.moveTo(0, -p.size)
+  ctx.lineTo(0, p.size)
+  ctx.stroke()
+  ctx.restore()
+}
+
+/**
+ * Рисует точку.
+ */
+function drawDot(ctx: CanvasRenderingContext2D, p: Particle) {
+  const color = getColor()
+  ctx.save()
+  ctx.globalAlpha = p.opacity * 0.6
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.restore()
+}
+
+/**
+ * Рисует пылинку — уменьшенная точка с повышенной прозрачностью.
+ */
+function drawDust(ctx: CanvasRenderingContext2D, p: Particle) {
+  const color = getColor()
+  ctx.save()
+  ctx.globalAlpha = p.opacity * 0.5
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(p.x, p.y, p.size * 0.7, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.restore()
+}
+
+/**
+ * Рисует уголёк — радиальный градиент от цвета к прозрачному.
+ */
+function drawEmber(ctx: CanvasRenderingContext2D, p: Particle) {
+  const color = getColor()
+  ctx.save()
+  ctx.globalAlpha = p.opacity * 0.7
+  const grd = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, p.size * 0.8)
+  grd.addColorStop(0, color)
+  grd.addColorStop(1, 'transparent')
+  ctx.fillStyle = grd
+  ctx.beginPath()
+  ctx.arc(p.x, p.y, p.size * 0.8, 0, Math.PI * 2)
+  ctx.fill()
+  ctx.restore()
+}
+
+/**
+ * Количество частиц для каждого типа анимации.
+ */
+const PARTICLE_COUNT: Record<ParticleType, number> = {
+  leaf: 22,
+  dust: 40,
+  dot: 35,
+  ember: 24,
+}
+
+/**
+ * Свойства компонента анимации.
+ */
+interface Props {
+  /** Тип анимации. */
+  type: ParticleType
+}
+
+/**
+ * Canvas-анимация фона — рендерится поверх страницы с pointer-events: none.
+ * Цвет частиц подтягивается из CSS-переменной --color-primary активной темы.
+ */
+export function ParticleCanvas({ type }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+    const parent = canvas.parentElement
+    if (!parent) return
+
+    const dpr = window.devicePixelRatio || 1
+
+    // Синхронизирует размер canvas с физическими пикселями родителя
+    const resize = () => {
+      const rect = parent.getBoundingClientRect()
+      canvas.width = rect.width * dpr
+      canvas.height = rect.height * dpr
+      canvas.style.width = rect.width + 'px'
+      canvas.style.height = rect.height + 'px'
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    }
+
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(parent)
+
+    const getW = () => canvas.width / dpr
+    const getH = () => canvas.height / dpr
+
+    const particles: Particle[] = Array.from({ length: PARTICLE_COUNT[type] }, () =>
+      makeParticle(getW(), getH(), type, true),
+    )
+
+    let raf: number
+    const tick = () => {
+      const w = getW()
+      const h = getH()
+      ctx.clearRect(0, 0, w, h)
+
+      particles.forEach((p, i) => {
+        p.sway += p.swaySpeed
+        p.x += p.vx + Math.sin(p.sway) * 0.3
+        p.y += p.vy
+        p.rot += p.vrot
+
+        if (type === 'leaf') drawLeaf(ctx, p)
+        else if (type === 'dust') drawDust(ctx, p)
+        else if (type === 'dot') drawDot(ctx, p)
+        else if (type === 'ember') drawEmber(ctx, p)
+
+        // Ember пересекает верхнюю границу, остальные — нижнюю
+        const isEmber = type === 'ember'
+        const outOfBounds = isEmber ? p.y < -30 : p.y > h + 30
+        if (outOfBounds) {
+          particles[i] = makeParticle(w, h, type)
+        }
+      })
+
+      raf = requestAnimationFrame(tick)
+    }
+
+    tick()
+
+    return () => {
+      cancelAnimationFrame(raf)
+      ro.disconnect()
+    }
+  }, [type])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 0 }}
+    />
+  )
+}

--- a/apps/web/src/pages/home/HomePage.module.scss
+++ b/apps/web/src/pages/home/HomePage.module.scss
@@ -73,7 +73,7 @@ $bp-md: 900px;
   }
 
   &--active {
-    background: white;
+    background: var(--color-paper, white);
     color: var(--color-primary, #4e7b6a);
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   }
@@ -124,7 +124,7 @@ $bp-md: 900px;
     gap: 8px;
     min-height: 120px;
   }
-  background: white;
+  background: var(--color-paper, white);
   border: 1px solid var(--color-divider, #e0e0e0);
   border-radius: 16px;
   cursor: pointer;
@@ -251,7 +251,7 @@ $bp-md: 900px;
   flex-direction: column;
   justify-content: space-between;
   padding: 22px;
-  background: white;
+  background: var(--color-paper, white);
   border: 1px solid var(--color-divider, #e0e0e0);
   border-radius: 18px;
   cursor: pointer;
@@ -311,9 +311,13 @@ $bp-md: 900px;
 
   // Тёмная карточка
   &--dark {
-    background: var(--sidebar-bg, #243d35);
+    background: var(--color-surface-variant, #243d35);
     border-color: transparent;
     color: var(--sidebar-text, #d8ebe4);
+
+    .bento__cell-title {
+      color: var(--sidebar-text, #d8ebe4);
+    }
 
     .bento__cell-desc {
       color: var(--sidebar-muted, rgba(216, 235, 228, 0.6));
@@ -347,6 +351,7 @@ $bp-md: 900px;
   font-size: 20px;
   font-weight: 600;
   letter-spacing: -0.02em;
+  color: var(--color-text, inherit);
 
   .bento__cell--hero & {
     font-size: 26px;
@@ -442,12 +447,20 @@ $bp-md: 900px;
   }
 }
 
+.bento__cell-cta-arrow {
+  display: none;
+
+  @media (max-width: $bp-sm) {
+    display: flex;
+  }
+}
+
 // ─── Полоска импорта ──────────────────────────────────────────────────────────
 
 .import-strip {
   margin: 0 36px 32px;
   padding: 10px 20px;
-  background: white;
+  background: var(--color-paper, white);
   border: 1px solid var(--color-divider, #e0e0e0);
   border-radius: 14px;
   display: flex;
@@ -542,5 +555,13 @@ $bp-md: 900px;
 .import-strip__btn-text {
   @media (max-width: $bp-sm) {
     display: none;
+  }
+}
+
+.import-strip__btn-arrow {
+  display: none;
+
+  @media (max-width: $bp-sm) {
+    display: flex;
   }
 }

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -196,7 +196,9 @@ function BentoLayout() {
         </div>
         <span className={styles['bento__cell-cta']}>
           <span className={styles['bento__cell-cta-text']}>Подключить</span>
-          <ArrowIcon />
+          <span className={styles['bento__cell-cta-arrow']}>
+            <ArrowIcon />
+          </span>
         </span>
       </button>
     </div>
@@ -220,7 +222,9 @@ function ImportStrip() {
       </div>
       <button className={styles['import-strip__btn']} disabled>
         <span className={styles['import-strip__btn-text']}>Подключить</span>
-        <ArrowIcon />
+        <span className={styles['import-strip__btn-arrow']}>
+          <ArrowIcon />
+        </span>
       </button>
     </div>
   )

--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -2,18 +2,34 @@ $bp-sm: 600px;
 $bp-md: 900px;
 
 @keyframes spin-slow {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes rise {
-  from { opacity: 0; transform: translateY(8px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes slide-in {
-  from { opacity: 0; transform: translateX(12px); }
-  to   { opacity: 1; transform: translateX(0); }
+  from {
+    opacity: 0;
+    transform: translateX(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 // ─── Страница ─────────────────────────────────────────────────────────────────
@@ -41,7 +57,7 @@ $bp-md: 900px;
   font-size: 18px;
   font-weight: 700;
   letter-spacing: -0.02em;
-  color: var(--sidebar-bg, #243d35);
+  color: var(--header-title-color, #243d35);
   animation: rise 0.6s ease both;
   display: flex;
   align-items: center;
@@ -90,8 +106,10 @@ $bp-md: 900px;
   @media (min-width: $bp-md) {
     width: 280px;
     padding: 12px 16px 24px;
-    background: var(--color-paper, white);
+    background: color-mix(in srgb, var(--color-paper, white) 70%, transparent);
     border-right: 1px solid var(--color-divider, #e0e0e0);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
   }
 }
 
@@ -110,7 +128,9 @@ $bp-md: 900px;
   cursor: pointer;
   text-align: left;
   width: 100%;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 
   &:hover {
     background: var(--color-paper-2, rgba(0, 0, 0, 0.05));
@@ -170,7 +190,9 @@ $bp-md: 900px;
 .settings__content {
   flex: 1;
   min-width: 0;
-  background: var(--color-paper-2, #f5f5f5);
+  background: color-mix(in srgb, var(--color-paper-2, #f5f5f5) 30%, transparent);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
   animation: slide-in 0.25s ease both;
 
   // На мобилке — прячем если нет выбранного раздела
@@ -217,6 +239,73 @@ $bp-md: 900px;
   letter-spacing: 0.06em;
 }
 
+// ─── Переключатель анимации ───────────────────────────────────────────────────
+
+.animation-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 20px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  // Непрозрачный фон — частицы за блоком не просвечивают
+  background: var(--color-paper, white);
+  border: 1px solid var(--color-divider, #e0e0e0);
+  position: relative;
+  isolation: isolate;
+}
+
+.animation-row__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.animation-row__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text, inherit);
+}
+
+.animation-row__desc {
+  font-size: 12px;
+  color: var(--color-text-2, #666);
+}
+
+.animation-toggle {
+  width: 44px;
+  height: 26px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-divider, #ccc);
+  padding: 3px;
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background 0.2s;
+
+  &--on {
+    background: var(--color-primary, #4e7b6a);
+  }
+}
+
+.animation-toggle__thumb {
+  display: block;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: white;
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  transition: transform 0.2s;
+
+  .animation-toggle--on & {
+    transform: translateX(18px);
+  }
+}
+
 // ─── Сетка тем ────────────────────────────────────────────────────────────────
 
 .theme-grid {
@@ -240,7 +329,10 @@ $bp-md: 900px;
   background: none;
   padding: 0;
   text-align: left;
-  transition: border-color 0.2s, transform 0.15s, box-shadow 0.2s;
+  transition:
+    border-color 0.2s,
+    transform 0.15s,
+    box-shadow 0.2s;
 
   &:hover {
     transform: translateY(-2px);
@@ -286,8 +378,12 @@ $bp-md: 900px;
   background: var(--color-divider, #e0e0e0);
   opacity: 0.6;
 
-  &--wide { width: 70%; }
-  &--narrow { width: 45%; }
+  &--wide {
+    width: 70%;
+  }
+  &--narrow {
+    width: 45%;
+  }
 }
 
 .theme-card__check {
@@ -310,7 +406,7 @@ $bp-md: 900px;
   font-size: 12px;
   font-weight: 500;
   color: var(--color-text, inherit);
-  background: white;
+  background: var(--color-paper, white);
 }
 
 .theme-card--active .theme-card__footer {

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
 import { ChevronLeft, ChevronRight, Check, Palette, Settings } from 'lucide-react'
+import { useNavigate, useParams } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import { setTheme } from '@/features/theme'
-import { THEMES_META } from '@/shared/config/themes'
+import { toggleParticles } from '@/features/animations'
+import { THEME_COLORS, THEMES_META } from '@/shared/config/themes'
 import type { ThemeVariant } from '@/shared/config/themes'
 import styles from './SettingsPage.module.scss'
 
@@ -26,7 +27,8 @@ interface SettingsSection {
  * Страница настроек приложения.
  */
 export function SettingsPage() {
-  const [activeSection, setActiveSection] = useState<string | null>(null)
+  const { section } = useParams<{ section: string }>()
+  const navigate = useNavigate()
 
   const sections: SettingsSection[] = [
     {
@@ -38,7 +40,7 @@ export function SettingsPage() {
     },
   ]
 
-  const active = sections.find((s) => s.id === activeSection)
+  const active = sections.find((s) => s.id === section)
 
   return (
     <div className={styles['settings']}>
@@ -54,16 +56,16 @@ export function SettingsPage() {
         <nav
           className={`${styles['settings__nav']} ${active ? styles['settings__nav--hidden'] : ''}`}
         >
-          {sections.map((section) => (
+          {sections.map((s) => (
             <button
-              key={section.id}
-              className={`${styles['settings__nav-item']} ${activeSection === section.id ? styles['settings__nav-item--active'] : ''}`}
-              onClick={() => setActiveSection(section.id)}
+              key={s.id}
+              className={`${styles['settings__nav-item']} ${section === s.id ? styles['settings__nav-item--active'] : ''}`}
+              onClick={() => navigate(`/settings/${s.id}`)}
             >
-              <div className={styles['settings__nav-icon']}>{section.icon}</div>
+              <div className={styles['settings__nav-icon']}>{s.icon}</div>
               <div className={styles['settings__nav-info']}>
-                <span className={styles['settings__nav-label']}>{section.label}</span>
-                <span className={styles['settings__nav-desc']}>{section.desc}</span>
+                <span className={styles['settings__nav-label']}>{s.label}</span>
+                <span className={styles['settings__nav-desc']}>{s.desc}</span>
               </div>
               <ChevronRight size={16} className={styles['settings__nav-chevron']} />
             </button>
@@ -73,7 +75,7 @@ export function SettingsPage() {
         {/* Контент выбранного раздела */}
         {active && (
           <div className={styles['settings__content']}>
-            <button className={styles['settings__back']} onClick={() => setActiveSection(null)}>
+            <button className={styles['settings__back']} onClick={() => navigate('/settings')}>
               <ChevronLeft size={16} />
               Назад
             </button>
@@ -101,22 +103,44 @@ export function SettingsPage() {
 function AppearanceContent() {
   const dispatch = useAppDispatch()
   const activeVariant = useAppSelector((s) => s.theme.variant)
+  const particlesEnabled = useAppSelector((s) => s.animations.particlesEnabled)
+  const isDarkTheme = THEME_COLORS[activeVariant].isDark ?? false
+  const hasParticles = !!THEME_COLORS[activeVariant].particle
 
   const handleSelect = (variant: ThemeVariant) => {
     dispatch(setTheme(variant))
   }
 
   return (
-    <div className={styles['theme-grid']}>
-      {THEMES_META.map((theme) => (
-        <ThemeCard
-          key={theme.variant}
-          theme={theme}
-          isActive={theme.variant === activeVariant}
-          onSelect={handleSelect}
-        />
-      ))}
-    </div>
+    <>
+      <div className={styles['theme-grid']}>
+        {THEMES_META.map((theme) => (
+          <ThemeCard
+            key={theme.variant}
+            theme={theme}
+            isActive={theme.variant === activeVariant}
+            isDarkTheme={isDarkTheme}
+            onSelect={handleSelect}
+          />
+        ))}
+      </div>
+
+      {hasParticles && (
+        <div className={styles['animation-row']}>
+          <div className={styles['animation-row__info']}>
+            <span className={styles['animation-row__label']}>Анимация</span>
+            <span className={styles['animation-row__desc']}>Фоновая анимация</span>
+          </div>
+          <button
+            className={`${styles['animation-toggle']} ${particlesEnabled ? styles['animation-toggle--on'] : ''}`}
+            onClick={() => dispatch(toggleParticles())}
+            aria-label={particlesEnabled ? 'Выключить анимацию' : 'Включить анимацию'}
+          >
+            <span className={styles['animation-toggle__thumb']} />
+          </button>
+        </div>
+      )}
+    </>
   )
 }
 
@@ -128,6 +152,8 @@ interface ThemeCardProps {
   theme: (typeof THEMES_META)[number]
   /** Флаг активной темы. */
   isActive: boolean
+  /** Флаг тёмной активной темы — используется для стилизации footer. */
+  isDarkTheme: boolean
   /** Функция выбора темы. */
   onSelect: (variant: ThemeVariant) => void
 }
@@ -135,7 +161,11 @@ interface ThemeCardProps {
 /**
  * Карточка выбора темы с визуальным превью цветов.
  */
-function ThemeCard({ theme, isActive, onSelect }: ThemeCardProps) {
+function ThemeCard({ theme, isActive, isDarkTheme, onSelect }: ThemeCardProps) {
+  const footerStyle = isDarkTheme
+    ? { background: '#1B1E25', color: isActive ? '#C97B5C' : '#E8E3DA' }
+    : undefined
+
   return (
     <button
       className={`${styles['theme-card']} ${isActive ? styles['theme-card--active'] : ''}`}
@@ -154,7 +184,9 @@ function ThemeCard({ theme, isActive, onSelect }: ThemeCardProps) {
           </span>
         )}
       </div>
-      <div className={styles['theme-card__footer']}>{theme.name}</div>
+      <div className={styles['theme-card__footer']} style={footerStyle}>
+        {theme.name}
+      </div>
     </button>
   )
 }

--- a/apps/web/src/shared/config/themes.ts
+++ b/apps/web/src/shared/config/themes.ts
@@ -1,7 +1,19 @@
 /**
  * Доступные варианты темы приложения.
  */
-export type ThemeVariant = 'sageLibrary' | 'warmLatte' | 'slate' | 'dustyPlum'
+export type ThemeVariant =
+  | 'sageLibrary'
+  | 'linen'
+  | 'slate'
+  | 'dustyPlum'
+  | 'navy'
+  | 'inkLight'
+  | 'sageDark'
+  | 'dune'
+  | 'slateDark'
+  | 'plumDark'
+  | 'navyDark'
+  | 'ink'
 
 /** Дефолтная тема приложения. */
 export const DEFAULT_THEME: ThemeVariant = 'sageLibrary'
@@ -35,6 +47,12 @@ export interface ThemeColors {
   sidebarMuted: string
   sidebarActiveBackground: string
   sidebarDivider: string
+  /** Флаг тёмной темы — MUI будет использовать mode: 'dark'. */
+  isDark?: boolean
+  /** Акцентная поверхность для тёмных блоков (bento dark cell и т.п.). */
+  surfaceVariant?: string
+  /** Тип анимации на главной странице. */
+  particle?: 'leaf' | 'dust' | 'dot' | 'ember'
 }
 
 /**
@@ -42,6 +60,7 @@ export interface ThemeColors {
  */
 export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
   sageLibrary: {
+    particle: 'leaf',
     primary: '#4E7B6A',
     primaryLight: '#6E9B8A',
     primaryDark: '#3D6A59',
@@ -61,27 +80,29 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarActiveBackground: 'rgba(255,255,255,0.09)',
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
-  warmLatte: {
-    primary: '#8B5E3C',
+  linen: {
+    particle: 'dust',
+    primary: '#8C5A3C',
     primaryLight: '#A87D5A',
-    primaryDark: '#7A5234',
-    primaryContrast: '#FFF8F2',
-    secondary: '#7A5C45',
-    secondaryLight: '#9A7A62',
-    secondaryDark: '#5E4432',
-    secondaryContrast: '#FFF8F2',
-    bgDefault: '#FAF6F0',
-    bgPaper: '#FFF8F2',
-    textPrimary: '#2C1810',
-    textSecondary: '#7A5C45',
-    divider: '#E8DDD0',
-    sidebarBg: '#2C1810',
-    sidebarText: '#E8DDD0',
-    sidebarMuted: 'rgba(232,221,208,0.5)',
-    sidebarActiveBackground: 'rgba(255,255,255,0.10)',
+    primaryDark: '#75482E',
+    primaryContrast: '#FBF8F2',
+    secondary: '#7A6A5A',
+    secondaryLight: '#9A8A7A',
+    secondaryDark: '#5A5040',
+    secondaryContrast: '#FBF8F2',
+    bgDefault: '#F5F1EA',
+    bgPaper: '#FBF8F2',
+    textPrimary: '#2B2520',
+    textSecondary: '#7A6A5A',
+    divider: '#E5DDCE',
+    sidebarBg: '#2B2520',
+    sidebarText: '#EDE3D4',
+    sidebarMuted: 'rgba(237,227,212,0.5)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.08)',
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   slate: {
+    particle: 'dot',
     primary: '#4361B0',
     primaryLight: '#6481C8',
     primaryDark: '#3451A0',
@@ -102,6 +123,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   dustyPlum: {
+    particle: 'dust',
     primary: '#7C5CA8',
     primaryLight: '#9C7CC8',
     primaryDark: '#6B4C97',
@@ -121,6 +143,189 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarActiveBackground: 'rgba(255,255,255,0.09)',
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
+  navy: {
+    particle: 'dot',
+    primary: '#3B4A66',
+    primaryLight: '#5B6A86',
+    primaryDark: '#2D3B53',
+    primaryContrast: '#FFFFFF',
+    secondary: '#5A6478',
+    secondaryLight: '#7A8498',
+    secondaryDark: '#3A4458',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#F4F5F7',
+    bgPaper: '#FFFFFF',
+    textPrimary: '#1A1F2A',
+    textSecondary: '#5A6478',
+    divider: '#DDE1E8',
+    sidebarBg: '#181C24',
+    sidebarText: '#D6DBE6',
+    sidebarMuted: 'rgba(214,219,230,0.5)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.08)',
+    sidebarDivider: 'rgba(255,255,255,0.07)',
+  },
+  inkLight: {
+    particle: 'ember',
+    primary: '#A8623A',
+    primaryLight: '#C97B5C',
+    primaryDark: '#8A4E2C',
+    primaryContrast: '#FFFFFF',
+    secondary: '#8A6A5A',
+    secondaryLight: '#AA8A7A',
+    secondaryDark: '#6A4A3A',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#F4EFE8',
+    bgPaper: '#FAF7F2',
+    textPrimary: '#2A1F15',
+    textSecondary: '#7A5A48',
+    divider: '#E5DDD0',
+    sidebarBg: '#2A1F15',
+    sidebarText: '#F5E8D8',
+    sidebarMuted: 'rgba(245,232,216,0.5)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.09)',
+    sidebarDivider: 'rgba(255,255,255,0.07)',
+  },
+
+  // ─── Тёмные пары к светлым темам ─────────────────────────────────────────────
+
+  sageDark: {
+    isDark: true,
+    particle: 'leaf',
+    surfaceVariant: '#1E2D28',
+    primary: '#6E9B8A',
+    primaryLight: '#8EBDAC',
+    primaryDark: '#5E8B7A',
+    primaryContrast: '#FFFFFF',
+    secondary: '#5A7A6A',
+    secondaryLight: '#7A9A8A',
+    secondaryDark: '#3A5A4A',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#141A17',
+    bgPaper: '#1A2220',
+    textPrimary: '#D8EBE4',
+    textSecondary: '#8AADA4',
+    divider: '#253028',
+    sidebarBg: '#0D1210',
+    sidebarText: '#D8EBE4',
+    sidebarMuted: 'rgba(216,235,228,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
+  dune: {
+    isDark: true,
+    particle: 'dust',
+    surfaceVariant: '#2A2521',
+    primary: '#C8A26A',
+    primaryLight: '#D4B98A',
+    primaryDark: '#B58F58',
+    primaryContrast: '#FFFFFF',
+    secondary: '#948977',
+    secondaryLight: '#B4A997',
+    secondaryDark: '#746957',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#1A1715',
+    bgPaper: '#221E1B',
+    textPrimary: '#EFE7D7',
+    textSecondary: '#948977',
+    divider: '#2E2A26',
+    sidebarBg: '#100E0C',
+    sidebarText: '#E8DFD0',
+    sidebarMuted: 'rgba(232,223,208,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
+  slateDark: {
+    isDark: true,
+    particle: 'dot',
+    surfaceVariant: '#1E2438',
+    primary: '#6481C8',
+    primaryLight: '#849BE8',
+    primaryDark: '#5471B8',
+    primaryContrast: '#FFFFFF',
+    secondary: '#5A6A90',
+    secondaryLight: '#7A8AB0',
+    secondaryDark: '#3A4A70',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#111318',
+    bgPaper: '#171A22',
+    textPrimary: '#D6DBE6',
+    textSecondary: '#8E97B0',
+    divider: '#22273A',
+    sidebarBg: '#0B0D14',
+    sidebarText: '#D6DBE6',
+    sidebarMuted: 'rgba(214,219,230,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
+  plumDark: {
+    isDark: true,
+    particle: 'dust',
+    surfaceVariant: '#1E1A2E',
+    primary: '#9C7CC8',
+    primaryLight: '#BCA0E0',
+    primaryDark: '#8C6CB8',
+    primaryContrast: '#FFFFFF',
+    secondary: '#8070A0',
+    secondaryLight: '#A090C0',
+    secondaryDark: '#604080',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#120F1A',
+    bgPaper: '#181422',
+    textPrimary: '#DDD5EE',
+    textSecondary: '#9080B0',
+    divider: '#261E3A',
+    sidebarBg: '#0C0A12',
+    sidebarText: '#DDD5EE',
+    sidebarMuted: 'rgba(221,213,238,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
+  navyDark: {
+    isDark: true,
+    particle: 'dot',
+    surfaceVariant: '#161B2E',
+    primary: '#7B8EB8',
+    primaryLight: '#9BAED8',
+    primaryDark: '#6B7EA8',
+    primaryContrast: '#FFFFFF',
+    secondary: '#5A6880',
+    secondaryLight: '#7A88A0',
+    secondaryDark: '#3A4860',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#0E1018',
+    bgPaper: '#131620',
+    textPrimary: '#D6DBE6',
+    textSecondary: '#7A8098',
+    divider: '#1E2235',
+    sidebarBg: '#090B12',
+    sidebarText: '#D6DBE6',
+    sidebarMuted: 'rgba(214,219,230,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
+  ink: {
+    isDark: true,
+    particle: 'ember',
+    surfaceVariant: '#21252D',
+    primary: '#C97B5C',
+    primaryLight: '#E0A688',
+    primaryDark: '#B36A4D',
+    primaryContrast: '#FFFFFF',
+    secondary: '#6B6860',
+    secondaryLight: '#8B8880',
+    secondaryDark: '#4B4840',
+    secondaryContrast: '#FFFFFF',
+    bgDefault: '#14161B',
+    bgPaper: '#1B1E25',
+    textPrimary: '#E8E3DA',
+    textSecondary: '#8E8B85',
+    divider: '#2A2E37',
+    sidebarBg: '#0E1014',
+    sidebarText: '#DDD7CE',
+    sidebarMuted: 'rgba(221,215,206,0.45)',
+    sidebarActiveBackground: 'rgba(255,255,255,0.06)',
+    sidebarDivider: 'rgba(255,255,255,0.05)',
+  },
 }
 
 /**
@@ -128,9 +333,17 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
  */
 const THEME_NAMES: Record<ThemeVariant, string> = {
   sageLibrary: 'Sage Library',
-  warmLatte: 'Warm Latte',
+  linen: 'Linen',
   slate: 'Slate',
   dustyPlum: 'Dusty Plum',
+  navy: 'Navy',
+  inkLight: 'Ink Light',
+  sageDark: 'Sage Dark',
+  dune: 'Dune',
+  slateDark: 'Slate Dark',
+  plumDark: 'Plum Dark',
+  navyDark: 'Navy Dark',
+  ink: 'Ink',
 }
 
 /**
@@ -142,4 +355,5 @@ export const THEMES_META = (Object.keys(THEME_COLORS) as ThemeVariant[]).map((va
   sidebarColor: THEME_COLORS[variant].sidebarBg,
   primaryColor: THEME_COLORS[variant].primary,
   bgColor: THEME_COLORS[variant].bgDefault,
+  isDark: THEME_COLORS[variant].isDark ?? false,
 }))

--- a/apps/web/src/widgets/layout/AppLayout.tsx
+++ b/apps/web/src/widgets/layout/AppLayout.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react'
 import { Box, Drawer, useMediaQuery, useTheme } from '@mui/material'
 import { Outlet } from 'react-router'
+import { useAppSelector } from '@/shared/lib/store'
+import { THEME_COLORS } from '@/shared/config/themes'
+import { ParticleCanvas } from '@/features/animations'
 import { Sidebar } from './Sidebar'
 import { MobileNav } from './MobileNav'
 
@@ -17,6 +20,11 @@ export const AppLayout = () => {
   const [collapsed, setCollapsed] = useState(false)
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH
+
+  const themeVariant = useAppSelector((s) => s.theme.variant)
+  const particlesEnabled = useAppSelector((s) => s.animations.particlesEnabled)
+  const particleType = THEME_COLORS[themeVariant].particle
+  const showParticles = particlesEnabled && !!particleType
 
   return (
     <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'background.default' }}>
@@ -45,10 +53,11 @@ export const AppLayout = () => {
           flexGrow: 1,
           overflow: 'auto',
           minWidth: 0,
-          // Отступ снизу на мобильном чтобы контент не перекрывался нижней навигацией
+          position: 'relative',
           pb: isMobile ? '56px' : 0,
         }}
       >
+        {showParticles && <ParticleCanvas type={particleType!} />}
         <Outlet />
       </Box>
 


### PR DESCRIPTION
## Summary

- Добавлено 12 тем оформления (6 светлых + 6 тёмных) с полным набором CSS-токенов
- Canvas-анимации частиц (leaf/dust/dot/ember) привязаны к теме, отображаются на всех страницах
- Страница настроек: выбор темы, тоггл анимации, URL-роутинг разделов (`/settings/:section`)
- Домашняя страница: grid/bento layout, унифицированные кнопки импорта

## Test plan

- [ ] Переключить все 12 тем — проверить цвета, анимации частиц
- [ ] Включить/выключить анимацию в настройках
- [ ] Открыть `/settings/appearance`, обновить страницу — должен остаться в разделе
- [ ] Проверить grid и bento layout на мобильном размере