### PR TITLE
Связать парные темы и добавить переключатель смены режима

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -17,48 +17,49 @@ interface Props {
  * Оборачивает приложение MUI ThemeProvider с текущей темой из store.
  */
 export const ThemeProvider = ({ children }: Props) => {
-  const variant = useAppSelector((s) => s.theme.variant)
-  const theme = useMemo(() => buildTheme(variant), [variant])
+  const { lightVariant, darkVariant, isDark } = useAppSelector((s) => s.theme)
+  const activeVariant = isDark ? darkVariant : lightVariant
+  const theme = useMemo(() => buildTheme(activeVariant), [activeVariant])
 
   useEffect(() => {
     const root = document.documentElement
     const { sidebar, primary, divider, text, background } = theme.palette
 
-    // Токены сайдбара и hero-секций
+    // Токены активной темы — используются во всём приложении
     root.style.setProperty('--sidebar-bg', sidebar.background)
     root.style.setProperty('--sidebar-text', sidebar.text)
     root.style.setProperty('--sidebar-muted', sidebar.muted)
     root.style.setProperty('--sidebar-divider', sidebar.divider)
 
-    // Токены акцентного цвета и разделителей
     root.style.setProperty('--color-primary', primary.main)
     root.style.setProperty('--color-primary-dark', primary.dark)
     root.style.setProperty('--color-divider', divider)
 
-    // Токены текста и поверхностей
     root.style.setProperty('--color-text', text.primary)
     root.style.setProperty('--color-text-2', text.secondary)
     root.style.setProperty('--color-paper', background.paper)
     root.style.setProperty('--color-paper-2', background.default)
 
-    // Токены чипов и плиток
     root.style.setProperty('--color-chip-bg', primary.light + '33')
     root.style.setProperty('--color-chip-text', primary.dark)
 
-    // Цвет заголовков на тематическом фоне — тёмный для светлых тем, светлый для тёмных
-    const isDark = THEME_COLORS[variant].isDark ?? false
     root.style.setProperty('--header-title-color', isDark ? sidebar.text : sidebar.background)
 
-    // Акцентная поверхность для тёмных блоков (bento dark cell и т.п.)
-    const surfaceVariant = THEME_COLORS[variant].surfaceVariant ?? sidebar.background
+    const surfaceVariant = THEME_COLORS[activeVariant].surfaceVariant ?? sidebar.background
     root.style.setProperty('--color-surface-variant', surfaceVariant)
 
-    // Токены кнопок на тёмном фоне сайдбара
     root.style.setProperty('--sidebar-btn-border', sidebar.activeBackground)
     root.style.setProperty('--sidebar-btn-outlined-border', 'rgba(255,255,255,.25)')
     root.style.setProperty('--sidebar-btn-disabled-border', 'rgba(255,255,255,.15)')
     root.style.setProperty('--sidebar-btn-disabled-color', 'rgba(255,255,255,.35)')
-  }, [theme, variant])
+
+    // Токены для страницы входа — всегда из светлой темы, не зависят от isDark.
+    // Это гарантирует что login page выглядит одинаково при любом режиме.
+    const lightColors = THEME_COLORS[lightVariant]
+    root.style.setProperty('--login-hero-bg', lightColors.sidebarBg)
+    root.style.setProperty('--login-hero-text', lightColors.sidebarText)
+    root.style.setProperty('--login-hero-muted', lightColors.sidebarMuted)
+  }, [theme, activeVariant, isDark, lightVariant])
 
   return (
     <StyledEngineProvider injectFirst>

--- a/apps/web/src/features/theme/index.ts
+++ b/apps/web/src/features/theme/index.ts
@@ -1,1 +1,8 @@
-export { default as themeReducer, setTheme } from './model/themeSlice'
+export {
+  default as themeReducer,
+  setPair,
+  setLightVariant,
+  setDarkVariant,
+  toggleDark,
+  setDark,
+} from './model/themeSlice'

--- a/apps/web/src/features/theme/model/themeSlice.ts
+++ b/apps/web/src/features/theme/model/themeSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { DEFAULT_THEME } from '@/shared/config/themes'
+import { DEFAULT_THEME, THEME_COLORS } from '@/shared/config/themes'
 import type { ThemeVariant } from '@/shared/config/themes'
 
 const STORAGE_KEY = 'treqio_theme'
@@ -9,31 +9,90 @@ const STORAGE_KEY = 'treqio_theme'
  * Состояние темы приложения.
  */
 interface ThemeState {
-  /** Текущий вариант палитры. */
-  variant: ThemeVariant
+  /** Выбранная светлая тема. */
+  lightVariant: ThemeVariant
+  /** Выбранная тёмная тема. */
+  darkVariant: ThemeVariant
+  /** Текущий режим отображения. */
+  isDark: boolean
+  /** Пользователь вручную выбрал темы из разных пар (расширенный режим). */
+  isCustomPair: boolean
 }
 
-/** Начальное состояние — читаем из localStorage, иначе дефолт. */
-const initialState: ThemeState = {
-  variant: (localStorage.getItem(STORAGE_KEY) as ThemeVariant | null) ?? DEFAULT_THEME,
+function loadState(): ThemeState {
+  const defaultDark = THEME_COLORS[DEFAULT_THEME].pair
+  const defaults: ThemeState = {
+    lightVariant: DEFAULT_THEME,
+    darkVariant: defaultDark,
+    isDark: false,
+    isCustomPair: false,
+  }
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) {
+      const parsed = JSON.parse(raw)
+      if (parsed.lightVariant && parsed.darkVariant) return parsed as ThemeState
+    }
+  } catch {
+    // ignore parse errors, fall back to defaults
+  }
+  return defaults
 }
 
-/**
- * Slice управления темой приложения.
- */
+function saveState(state: ThemeState) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
 const themeSlice = createSlice({
   name: 'theme',
-  initialState,
+  initialState: loadState,
   reducers: {
     /**
-     * Смена варианта палитры. Сохраняет выбор в localStorage.
+     * Простой режим: выбор пары целиком по светлой теме.
+     * Автоматически устанавливает обе темы и сбрасывает кастомную пару.
      */
-    setTheme: (state, action: PayloadAction<ThemeVariant>) => {
-      state.variant = action.payload
-      localStorage.setItem(STORAGE_KEY, action.payload)
+    setPair: (state, action: PayloadAction<ThemeVariant>) => {
+      state.lightVariant = action.payload
+      state.darkVariant = THEME_COLORS[action.payload].pair
+      state.isCustomPair = false
+      saveState({ ...state })
+    },
+
+    /**
+     * Расширенный режим: только светлая тема, тёмная не меняется.
+     */
+    setLightVariant: (state, action: PayloadAction<ThemeVariant>) => {
+      state.lightVariant = action.payload
+      state.isCustomPair = action.payload !== THEME_COLORS[state.darkVariant].pair
+      saveState({ ...state })
+    },
+
+    /**
+     * Расширенный режим: только тёмная тема, светлая не меняется.
+     */
+    setDarkVariant: (state, action: PayloadAction<ThemeVariant>) => {
+      state.darkVariant = action.payload
+      state.isCustomPair = action.payload !== THEME_COLORS[state.lightVariant].pair
+      saveState({ ...state })
+    },
+
+    /**
+     * Переключение между светлым и тёмным режимом.
+     */
+    toggleDark: (state) => {
+      state.isDark = !state.isDark
+      saveState({ ...state })
+    },
+
+    /**
+     * Явная установка режима (светлый/тёмный).
+     */
+    setDark: (state, action: PayloadAction<boolean>) => {
+      state.isDark = action.payload
+      saveState({ ...state })
     },
   },
 })
 
-export const { setTheme } = themeSlice.actions
+export const { setPair, setLightVariant, setDarkVariant, toggleDark, setDark } = themeSlice.actions
 export default themeSlice.reducer

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -31,7 +31,7 @@ const TILES = [
     icon: <Palette size={22} />,
     title: 'Настроить тему',
     desc: 'Цветовая палитра и шрифт интерфейса.',
-    href: '/settings',
+    href: '/settings/appearance',
   },
 ]
 

--- a/apps/web/src/pages/login/LoginPage.module.scss
+++ b/apps/web/src/pages/login/LoginPage.module.scss
@@ -48,8 +48,8 @@ $bp-md: 900px;
   flex-direction: column;
   align-items: center;
   text-align: center;
-  background: var(--sidebar-bg);
-  color: var(--sidebar-text);
+  background: var(--login-hero-bg);
+  color: var(--login-hero-text);
   padding-top: 112px; // pt xs=14 → 14×8px
   padding-bottom: 0;
   overflow: hidden;
@@ -66,7 +66,7 @@ $bp-md: 900px;
   font-size: 40px;
   font-weight: 800;
   letter-spacing: -0.05em;
-  color: var(--sidebar-text);
+  color: var(--login-hero-text);
   margin-bottom: 16px;
   animation: fade-slide-up 0.6s ease both;
 
@@ -80,7 +80,7 @@ $bp-md: 900px;
 .login-page__description {
   font-size: 15px;
   line-height: 1.6;
-  color: var(--sidebar-muted);
+  color: var(--login-hero-muted);
   max-width: 420px;
   margin-bottom: 32px;
   animation: fade-slide-up 0.6s ease 0.15s both;
@@ -132,7 +132,7 @@ $bp-md: 900px;
   gap: 12px;
   width: 100%;
   margin: 12px 0;
-  color: var(--sidebar-muted);
+  color: var(--login-hero-muted);
   font-size: 13px;
 
   @media (min-width: $bp-sm) {
@@ -163,7 +163,7 @@ $bp-md: 900px;
     padding-right: 28px;
     width: 100%;
     border-color: var(--sidebar-btn-outlined-border);
-    color: var(--sidebar-text);
+    color: var(--login-hero-text);
 
     &.Mui-disabled {
       border-color: var(--sidebar-btn-disabled-border);
@@ -180,7 +180,7 @@ $bp-md: 900px;
 
 .login-page__hint {
   font-size: 12px;
-  color: var(--sidebar-muted);
+  color: var(--login-hero-muted);
   margin-top: 12px;
   text-align: center;
 

--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -306,6 +306,95 @@ $bp-md: 900px;
   }
 }
 
+// ─── Переключатель режима (простой / раздельный) ─────────────────────────────
+
+.theme-mode-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.theme-mode-label {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text, inherit);
+}
+
+.theme-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
+  border: 1px solid var(--color-divider, #e0e0e0);
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.theme-mode-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 10px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: rgba(128, 128, 128, 0.15);
+    color: var(--color-text, inherit);
+  }
+
+  &--active {
+    background: var(--color-paper, white);
+    color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.15);
+  }
+}
+
+// ─── Секция тем (светлая / тёмная) ───────────────────────────────────────────
+
+.theme-section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  & + & {
+    margin-top: 20px;
+  }
+}
+
+.theme-section__label {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-2, #666);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-section__badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+  padding: 2px 7px;
+  border-radius: 999px;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+}
+
 // ─── Сетка тем ────────────────────────────────────────────────────────────────
 
 .theme-grid {

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -1,11 +1,22 @@
-import { ChevronLeft, ChevronRight, Check, Palette, Settings } from 'lucide-react'
+import { useState } from 'react'
+import {
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  Palette,
+  Settings,
+  Layers,
+  LayoutGrid,
+} from 'lucide-react'
 import { useNavigate, useParams } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
-import { setTheme } from '@/features/theme'
+import { setPair, setLightVariant, setDarkVariant } from '@/features/theme'
 import { toggleParticles } from '@/features/animations'
-import { THEME_COLORS, THEMES_META } from '@/shared/config/themes'
+import { THEME_COLORS, LIGHT_THEMES, DARK_THEMES } from '@/shared/config/themes'
 import type { ThemeVariant } from '@/shared/config/themes'
 import styles from './SettingsPage.module.scss'
+
+const THEME_MODE_KEY = 'treqio_theme_picker_mode'
 
 /**
  * Раздел настроек.
@@ -52,7 +63,6 @@ export function SettingsPage() {
       </div>
 
       <div className={styles['settings__body']}>
-        {/* Список разделов */}
         <nav
           className={`${styles['settings__nav']} ${active ? styles['settings__nav--hidden'] : ''}`}
         >
@@ -72,7 +82,6 @@ export function SettingsPage() {
           ))}
         </nav>
 
-        {/* Контент выбранного раздела */}
         {active && (
           <div className={styles['settings__content']}>
             <button className={styles['settings__back']} onClick={() => navigate('/settings')}>
@@ -86,7 +95,6 @@ export function SettingsPage() {
           </div>
         )}
 
-        {/* На десктопе — показываем контент сразу при выборе из списка */}
         {!active && (
           <div
             className={`${styles['settings__content']} ${styles['settings__content--hidden']}`}
@@ -102,28 +110,88 @@ export function SettingsPage() {
  */
 function AppearanceContent() {
   const dispatch = useAppDispatch()
-  const activeVariant = useAppSelector((s) => s.theme.variant)
+  const { lightVariant, darkVariant, isDark } = useAppSelector((s) => s.theme)
   const particlesEnabled = useAppSelector((s) => s.animations.particlesEnabled)
-  const isDarkTheme = THEME_COLORS[activeVariant].isDark ?? false
+  const activeVariant = isDark ? darkVariant : lightVariant
   const hasParticles = !!THEME_COLORS[activeVariant].particle
 
-  const handleSelect = (variant: ThemeVariant) => {
-    dispatch(setTheme(variant))
+  const [advancedMode, setAdvancedMode] = useState<boolean>(
+    () => localStorage.getItem(THEME_MODE_KEY) === 'advanced',
+  )
+
+  const handleModeChange = (mode: 'simple' | 'advanced') => {
+    setAdvancedMode(mode === 'advanced')
+    localStorage.setItem(THEME_MODE_KEY, mode)
+  }
+
+  const handleSimpleSelect = (variant: ThemeVariant) => {
+    dispatch(setPair(variant))
   }
 
   return (
     <>
-      <div className={styles['theme-grid']}>
-        {THEMES_META.map((theme) => (
-          <ThemeCard
-            key={theme.variant}
-            theme={theme}
-            isActive={theme.variant === activeVariant}
-            isDarkTheme={isDarkTheme}
-            onSelect={handleSelect}
-          />
-        ))}
+      <div className={styles['theme-mode-header']}>
+        <span className={styles['theme-mode-label']}>Тема оформления</span>
+        <div className={styles['theme-mode-toggle']}>
+          <button
+            className={`${styles['theme-mode-btn']} ${!advancedMode ? styles['theme-mode-btn--active'] : ''}`}
+            onClick={() => handleModeChange('simple')}
+          >
+            <LayoutGrid size={13} />
+            Простой
+          </button>
+          <button
+            className={`${styles['theme-mode-btn']} ${advancedMode ? styles['theme-mode-btn--active'] : ''}`}
+            onClick={() => handleModeChange('advanced')}
+          >
+            <Layers size={13} />
+            Расширенный
+          </button>
+        </div>
       </div>
+
+      {!advancedMode ? (
+        <div className={styles['theme-grid']}>
+          {LIGHT_THEMES.map((t) => (
+            <ThemeCard
+              key={t.variant}
+              theme={t}
+              isActive={t.variant === lightVariant}
+              onSelect={handleSimpleSelect}
+            />
+          ))}
+        </div>
+      ) : (
+        <>
+          <div className={styles['theme-section']}>
+            <p className={styles['theme-section__label']}>Светлая тема</p>
+            <div className={styles['theme-grid']}>
+              {LIGHT_THEMES.map((t) => (
+                <ThemeCard
+                  key={t.variant}
+                  theme={t}
+                  isActive={t.variant === lightVariant}
+                  onSelect={(v) => dispatch(setLightVariant(v))}
+                />
+              ))}
+            </div>
+          </div>
+
+          <div className={styles['theme-section']}>
+            <p className={styles['theme-section__label']}>Тёмная тема</p>
+            <div className={styles['theme-grid']}>
+              {DARK_THEMES.map((t) => (
+                <ThemeCard
+                  key={t.variant}
+                  theme={t}
+                  isActive={t.variant === darkVariant}
+                  onSelect={(v) => dispatch(setDarkVariant(v))}
+                />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
 
       {hasParticles && (
         <div className={styles['animation-row']}>
@@ -144,26 +212,22 @@ function AppearanceContent() {
   )
 }
 
-/**
- * Свойства карточки темы.
- */
-interface ThemeCardProps {
-  /** Метаданные темы. */
-  theme: (typeof THEMES_META)[number]
-  /** Флаг активной темы. */
-  isActive: boolean
-  /** Флаг тёмной активной темы — используется для стилизации footer. */
-  isDarkTheme: boolean
-  /** Функция выбора темы. */
-  onSelect: (variant: ThemeVariant) => void
-}
+type ThemeMeta = (typeof LIGHT_THEMES)[number]
 
 /**
  * Карточка выбора темы с визуальным превью цветов.
  */
-function ThemeCard({ theme, isActive, isDarkTheme, onSelect }: ThemeCardProps) {
-  const footerStyle = isDarkTheme
-    ? { background: '#1B1E25', color: isActive ? '#C97B5C' : '#E8E3DA' }
+function ThemeCard({
+  theme,
+  isActive,
+  onSelect,
+}: {
+  theme: ThemeMeta
+  isActive: boolean
+  onSelect: (variant: ThemeVariant) => void
+}) {
+  const footerStyle = theme.isDark
+    ? { background: theme.bgColor, color: isActive ? theme.primaryColor : '#E8E3DA' }
     : undefined
 
   return (

--- a/apps/web/src/shared/config/themes.ts
+++ b/apps/web/src/shared/config/themes.ts
@@ -53,6 +53,8 @@ export interface ThemeColors {
   surfaceVariant?: string
   /** Тип анимации на главной странице. */
   particle?: 'leaf' | 'dust' | 'dot' | 'ember'
+  /** Парная тема (светлая ↔ тёмная). */
+  pair: ThemeVariant
 }
 
 /**
@@ -60,6 +62,7 @@ export interface ThemeColors {
  */
 export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
   sageLibrary: {
+    pair: 'sageDark',
     particle: 'leaf',
     primary: '#4E7B6A',
     primaryLight: '#6E9B8A',
@@ -81,6 +84,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   linen: {
+    pair: 'dune',
     particle: 'dust',
     primary: '#8C5A3C',
     primaryLight: '#A87D5A',
@@ -102,6 +106,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   slate: {
+    pair: 'slateDark',
     particle: 'dot',
     primary: '#4361B0',
     primaryLight: '#6481C8',
@@ -123,6 +128,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   dustyPlum: {
+    pair: 'plumDark',
     particle: 'dust',
     primary: '#7C5CA8',
     primaryLight: '#9C7CC8',
@@ -144,6 +150,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   navy: {
+    pair: 'navyDark',
     particle: 'dot',
     primary: '#3B4A66',
     primaryLight: '#5B6A86',
@@ -165,6 +172,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.07)',
   },
   inkLight: {
+    pair: 'ink',
     particle: 'ember',
     primary: '#A8623A',
     primaryLight: '#C97B5C',
@@ -189,6 +197,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
   // ─── Тёмные пары к светлым темам ─────────────────────────────────────────────
 
   sageDark: {
+    pair: 'sageLibrary',
     isDark: true,
     particle: 'leaf',
     surfaceVariant: '#1E2D28',
@@ -212,6 +221,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.05)',
   },
   dune: {
+    pair: 'linen',
     isDark: true,
     particle: 'dust',
     surfaceVariant: '#2A2521',
@@ -235,6 +245,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.05)',
   },
   slateDark: {
+    pair: 'slate',
     isDark: true,
     particle: 'dot',
     surfaceVariant: '#1E2438',
@@ -258,6 +269,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.05)',
   },
   plumDark: {
+    pair: 'dustyPlum',
     isDark: true,
     particle: 'dust',
     surfaceVariant: '#1E1A2E',
@@ -281,6 +293,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.05)',
   },
   navyDark: {
+    pair: 'navy',
     isDark: true,
     particle: 'dot',
     surfaceVariant: '#161B2E',
@@ -304,6 +317,7 @@ export const THEME_COLORS: Record<ThemeVariant, ThemeColors> = {
     sidebarDivider: 'rgba(255,255,255,0.05)',
   },
   ink: {
+    pair: 'inkLight',
     isDark: true,
     particle: 'ember',
     surfaceVariant: '#21252D',
@@ -337,12 +351,12 @@ const THEME_NAMES: Record<ThemeVariant, string> = {
   slate: 'Slate',
   dustyPlum: 'Dusty Plum',
   navy: 'Navy',
-  inkLight: 'Ink Light',
-  sageDark: 'Sage Dark',
-  dune: 'Dune',
-  slateDark: 'Slate Dark',
-  plumDark: 'Plum Dark',
-  navyDark: 'Navy Dark',
+  inkLight: 'Ink',
+  sageDark: 'Sage Library',
+  dune: 'Linen',
+  slateDark: 'Slate',
+  plumDark: 'Dusty Plum',
+  navyDark: 'Navy',
   ink: 'Ink',
 }
 
@@ -357,3 +371,9 @@ export const THEMES_META = (Object.keys(THEME_COLORS) as ThemeVariant[]).map((va
   bgColor: THEME_COLORS[variant].bgDefault,
   isDark: THEME_COLORS[variant].isDark ?? false,
 }))
+
+/** Метаданные только светлых тем. */
+export const LIGHT_THEMES = THEMES_META.filter((t) => !t.isDark)
+
+/** Метаданные только тёмных тем. */
+export const DARK_THEMES = THEMES_META.filter((t) => t.isDark)

--- a/apps/web/src/widgets/layout/AppLayout.tsx
+++ b/apps/web/src/widgets/layout/AppLayout.tsx
@@ -21,9 +21,10 @@ export const AppLayout = () => {
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH
 
-  const themeVariant = useAppSelector((s) => s.theme.variant)
+  const { lightVariant, darkVariant, isDark } = useAppSelector((s) => s.theme)
+  const activeVariant = isDark ? darkVariant : lightVariant
   const particlesEnabled = useAppSelector((s) => s.animations.particlesEnabled)
-  const particleType = THEME_COLORS[themeVariant].particle
+  const particleType = THEME_COLORS[activeVariant].particle
   const showParticles = particlesEnabled && !!particleType
 
   return (

--- a/apps/web/src/widgets/layout/Sidebar.module.scss
+++ b/apps/web/src/widgets/layout/Sidebar.module.scss
@@ -1,0 +1,144 @@
+.sidebar {
+  height: 100%;
+  background: var(--sidebar-bg);
+  color: var(--sidebar-text);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+// ─── Шапка ────────────────────────────────────────────────────────────────────
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 16px 14px;
+  border-bottom: 1px solid var(--sidebar-divider);
+  flex-shrink: 0;
+
+  &--collapsed {
+    justify-content: center;
+  }
+}
+
+.sidebar__logo {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--sidebar-text);
+  user-select: none;
+}
+
+.sidebar__collapse-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  border: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--sidebar-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sidebar-btn-border);
+    color: var(--sidebar-text);
+  }
+}
+
+// ─── Навигация ────────────────────────────────────────────────────────────────
+
+.sidebar__nav {
+  flex: 1;
+  padding: 12px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  align-items: stretch;
+}
+
+// ─── Футер ────────────────────────────────────────────────────────────────────
+
+.sidebar__footer {
+  padding: 12px 8px;
+  border-top: 1px solid var(--sidebar-divider);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+// ─── Пункт навигации ──────────────────────────────────────────────────────────
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--sidebar-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-family: inherit;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sidebar-btn-border);
+    color: var(--sidebar-text);
+  }
+
+  &--active {
+    background: var(--sidebar-btn-border);
+    color: var(--sidebar-text);
+  }
+
+  &--collapsed {
+    justify-content: center;
+  }
+}
+
+.nav-item__label {
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  color: inherit;
+}
+
+// ─── Переключатель темы ───────────────────────────────────────────────────────
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--sidebar-muted);
+  cursor: pointer;
+  font-family: inherit;
+  text-align: left;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--sidebar-btn-border);
+    color: var(--sidebar-text);
+  }
+
+  &--collapsed {
+    justify-content: center;
+    padding: 8px;
+  }
+}
+
+.theme-toggle__label {
+  font-size: 14px;
+  font-weight: 500;
+  color: inherit;
+  white-space: nowrap;
+}

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -8,25 +8,22 @@ import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined'
 import type { SvgIconComponent } from '@mui/icons-material'
-import { Box, IconButton, List, Typography } from '@mui/material'
-import { useTheme } from '@mui/material/styles'
+import { Tooltip } from '@mui/material'
+import { Moon, Sun } from 'lucide-react'
 import { Link, useMatch } from 'react-router'
+import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
+import { toggleDark } from '@/features/theme'
+import styles from './Sidebar.module.scss'
 
 /**
  * Конфигурация пункта навигации.
  */
 interface NavItemConfig {
-  /** Путь роута. */
   to: string
-  /** Иконка MUI. */
   icon: SvgIconComponent
-  /** Подпись пункта меню. */
   label: string
 }
 
-/**
- * Основные пункты навигации.
- */
 const NAV_ITEMS: NavItemConfig[] = [
   { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
   { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
@@ -36,54 +33,25 @@ const NAV_ITEMS: NavItemConfig[] = [
   { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск' },
 ]
 
-/**
- * Пункты в подвале сайдбара.
- */
 const FOOTER_ITEMS: NavItemConfig[] = [
   { to: '/settings', icon: SettingsOutlinedIcon, label: 'Настройки' },
 ]
 
-/**
- * Свойства пункта навигации с состоянием сайдбара.
- */
 interface NavItemProps extends NavItemConfig {
-  /** Флаг свёрнутости сайдбара. */
   collapsed: boolean
 }
 
 const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
-  const isActive = !!useMatch(to)
-  const { palette } = useTheme()
-  const sidebar = palette.sidebar
+  const isActive = !!useMatch({ path: to, end: to === '/' })
 
   return (
-    <Box
-      component={Link}
+    <Link
       to={to}
-      sx={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: '12px',
-        px: '10px',
-        py: '8px',
-        borderRadius: '8px',
-        textDecoration: 'none',
-        color: isActive ? sidebar.text : sidebar.muted,
-        bgcolor: isActive ? sidebar.activeBackground : 'transparent',
-        justifyContent: collapsed ? 'center' : 'flex-start',
-        cursor: 'pointer',
-        flexShrink: 0,
-        transition: 'background 0.15s, color 0.15s',
-        '&:hover': { bgcolor: sidebar.activeBackground, color: sidebar.text },
-      }}
+      className={`${styles['nav-item']} ${isActive ? styles['nav-item--active'] : ''} ${collapsed ? styles['nav-item--collapsed'] : ''}`}
     >
-      <Icon sx={{ fontSize: 22, flexShrink: 0 }} />
-      {!collapsed && (
-        <Typography sx={{ fontSize: 14, fontWeight: 500, whiteSpace: 'nowrap', color: 'inherit' }}>
-          {label}
-        </Typography>
-      )}
-    </Box>
+      <Icon style={{ fontSize: 22, flexShrink: 0 }} />
+      {!collapsed && <span className={styles['nav-item__label']}>{label}</span>}
+    </Link>
   )
 }
 
@@ -91,9 +59,7 @@ const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
  * Свойства сайдбара.
  */
 interface Props {
-  /** Флаг свёрнутости сайдбара. */
   collapsed: boolean
-  /** Функция переключения состояния свёрнутости. */
   onToggle: () => void
 }
 
@@ -101,97 +67,49 @@ interface Props {
  * Боковое меню приложения.
  */
 export const Sidebar = ({ collapsed, onToggle }: Props) => {
-  const { palette } = useTheme()
-  const sidebar = palette.sidebar
+  const dispatch = useAppDispatch()
+  const isDark = useAppSelector((s) => s.theme.isDark)
 
   return (
-    <Box
-      sx={{
-        height: '100%',
-        bgcolor: sidebar.background,
-        color: sidebar.text,
-        display: 'flex',
-        flexDirection: 'column',
-        overflow: 'hidden',
-      }}
-    >
-      {/* Шапка: логотип + кнопка сворачивания */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: collapsed ? 'center' : 'space-between',
-          px: 2,
-          pt: '18px',
-          pb: '14px',
-          borderBottom: `1px solid ${sidebar.divider}`,
-          flexShrink: 0,
-        }}
+    <div className={styles['sidebar']}>
+      <div
+        className={`${styles['sidebar__header']} ${collapsed ? styles['sidebar__header--collapsed'] : ''}`}
       >
-        {!collapsed && (
-          <Typography
-            sx={{
-              fontSize: 17,
-              fontWeight: 700,
-              letterSpacing: '-0.02em',
-              color: sidebar.text,
-              userSelect: 'none',
-            }}
-          >
-            Treqio
-          </Typography>
-        )}
-        <IconButton
-          onClick={onToggle}
-          size="small"
-          sx={{
-            color: sidebar.muted,
-            borderRadius: '6px',
-            bgcolor: 'rgba(255,255,255,0.05)',
-            '&:hover': { bgcolor: sidebar.activeBackground, color: sidebar.text },
-          }}
-        >
+        {!collapsed && <span className={styles['sidebar__logo']}>Treqio</span>}
+        <button className={styles['sidebar__collapse-btn']} onClick={onToggle}>
           {collapsed ? (
-            <ChevronRightIcon sx={{ fontSize: 20 }} />
+            <ChevronRightIcon style={{ fontSize: 20 }} />
           ) : (
-            <ChevronLeftIcon sx={{ fontSize: 20 }} />
+            <ChevronLeftIcon style={{ fontSize: 20 }} />
           )}
-        </IconButton>
-      </Box>
+        </button>
+      </div>
 
-      {/* Основная навигация */}
-      <Box
-        sx={{
-          flex: 1,
-          px: 1,
-          py: '12px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-          alignItems: 'stretch',
-        }}
-      >
+      <nav className={styles['sidebar__nav']}>
         {NAV_ITEMS.map((item) => (
           <NavItem key={item.to} {...item} collapsed={collapsed} />
         ))}
-      </Box>
+      </nav>
 
-      {/* Футер: настройки */}
-      <List
-        disablePadding
-        sx={{
-          px: 1,
-          py: '12px',
-          borderTop: `1px solid ${sidebar.divider}`,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '4px',
-        }}
-      >
+      <div className={styles['sidebar__footer']}>
+        <Tooltip title={isDark ? 'Светлая тема' : 'Тёмная тема'} placement="right">
+          <button
+            className={`${styles['theme-toggle']} ${collapsed ? styles['theme-toggle--collapsed'] : ''}`}
+            onClick={() => dispatch(toggleDark())}
+          >
+            {isDark ? <Sun size={22} /> : <Moon size={22} />}
+            {!collapsed && (
+              <span className={styles['theme-toggle__label']}>
+                {isDark ? 'Светлая тема' : 'Тёмная тема'}
+              </span>
+            )}
+          </button>
+        </Tooltip>
+
         {FOOTER_ITEMS.map((item) => (
           <NavItem key={item.to} {...item} collapsed={collapsed} />
         ))}
-      </List>
-    </Box>
+      </div>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary

- Поле `pair` у всех 12 тем, экспорты `LIGHT_THEMES` / `DARK_THEMES`
- `themeSlice`: состояние `lightVariant`, `darkVariant`, `isDark`, `isCustomPair`
- Три экшена: `setPair` (простой режим), `setLightVariant` / `setDarkVariant` (расширенный)
- Простой режим выбирает пару целиком, расширенный — светлую и тёмную независимо
- Страница входа всегда использует цвета светлой темы независимо от `isDark`
- Кнопка Sun/Moon в сайдбаре для переключения режима
- Sidebar переписан на SCSS модули, убраны все `sx` пропсы

## Test plan

- [ ] Простой режим: выбрать тему — применяется и светлая и тёмная пара
- [ ] Переключатель Sun/Moon переключает между парой
- [ ] Расширенный режим: светлая и тёмная выбираются независимо
- [ ] Страница входа не чернеет при тёмной теме
- [ ] Пункт «Настройки» в сайдбаре остаётся активным при открытом подразделе