### PR TITLE
fix(web): убрать мерцание скролла на странице настроек

### DIFF
--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -38,7 +38,7 @@ $bp-md: 900px;
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .settings__header {
@@ -76,11 +76,7 @@ $bp-md: 900px;
   display: flex;
   flex: 1;
   min-height: 0;
-  gap: 0;
-
-  @media (min-width: $bp-md) {
-    gap: 0;
-  }
+  overflow: hidden;
 }
 
 // ─── Список разделов ──────────────────────────────────────────────────────────
@@ -190,6 +186,8 @@ $bp-md: 900px;
 .settings__content {
   flex: 1;
   min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
   background: color-mix(in srgb, var(--color-paper-2, #f5f5f5) 30%, transparent);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);


### PR DESCRIPTION
## Summary

При навигации в настройках на долю секунды появлялись горизонтальный и вертикальный скроллбары с белым фоном.

Причина: анимации `slide-in` (translateX) и `rise` (translateY) на `.settings__content` и `.settings__nav` кратковременно выходили за границы контейнера. Плюс два вложенных scroll-контейнера (main + .settings).

Исправление:
- `overflow: hidden` на `.settings` и `.settings__body` — клипает артефакты анимаций
- `overflow-y: auto` перенесён на `.settings__content` — скролл только там где нужен

## Test plan

- [ ] Навигация на страницу настроек — скролл не мерцает
- [ ] Переход в «Внешний вид» и обратно — скролл не мерцает
- [ ] Расширенный режим тем — скролл внутри правой панели работает корректно