### PR TITLE
Системная тема и выбор цветовой схемы в настройках

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo } from 'react'
 import { CssBaseline, StyledEngineProvider, ThemeProvider as MuiThemeProvider } from '@mui/material'
 import type { ReactNode } from 'react'
-import { useAppSelector } from '@/shared/lib/store'
+import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
+import { setDark } from '@/features/theme'
 import { THEME_COLORS } from '@/shared/config/themes'
 import { buildTheme } from '../styles/theme'
 
@@ -17,9 +18,20 @@ interface Props {
  * Оборачивает приложение MUI ThemeProvider с текущей темой из store.
  */
 export const ThemeProvider = ({ children }: Props) => {
-  const { lightVariant, darkVariant, isDark } = useAppSelector((s) => s.theme)
+  const dispatch = useAppDispatch()
+  const { lightVariant, darkVariant, isDark, themeMode } = useAppSelector((s) => s.theme)
   const activeVariant = isDark ? darkVariant : lightVariant
   const theme = useMemo(() => buildTheme(activeVariant), [activeVariant])
+
+  // Следим за системной темой когда выбран режим «Как на устройстве»
+  useEffect(() => {
+    if (themeMode !== 'system') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    dispatch(setDark(mq.matches))
+    const handler = (e: MediaQueryListEvent) => dispatch(setDark(e.matches))
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [themeMode, dispatch])
 
   useEffect(() => {
     const root = document.documentElement

--- a/apps/web/src/features/theme/index.ts
+++ b/apps/web/src/features/theme/index.ts
@@ -3,6 +3,8 @@ export {
   setPair,
   setLightVariant,
   setDarkVariant,
+  setThemeMode,
   toggleDark,
   setDark,
 } from './model/themeSlice'
+export type { ThemeMode } from './model/themeSlice'

--- a/apps/web/src/features/theme/model/themeSlice.ts
+++ b/apps/web/src/features/theme/model/themeSlice.ts
@@ -5,6 +5,8 @@ import type { ThemeVariant } from '@/shared/config/themes'
 
 const STORAGE_KEY = 'treqio_theme'
 
+export type ThemeMode = 'light' | 'dark' | 'system'
+
 /**
  * Состояние темы приложения.
  */
@@ -13,7 +15,9 @@ interface ThemeState {
   lightVariant: ThemeVariant
   /** Выбранная тёмная тема. */
   darkVariant: ThemeVariant
-  /** Текущий режим отображения. */
+  /** Текущий активный режим (light/dark/system). */
+  themeMode: ThemeMode
+  /** Вычисленный флаг тёмного режима — управляется themeMode и ОС при system. */
   isDark: boolean
   /** Пользователь вручную выбрал темы из разных пар (расширенный режим). */
   isCustomPair: boolean
@@ -24,6 +28,7 @@ function loadState(): ThemeState {
   const defaults: ThemeState = {
     lightVariant: DEFAULT_THEME,
     darkVariant: defaultDark,
+    themeMode: 'light',
     isDark: false,
     isCustomPair: false,
   }
@@ -49,7 +54,6 @@ const themeSlice = createSlice({
   reducers: {
     /**
      * Простой режим: выбор пары целиком по светлой теме.
-     * Автоматически устанавливает обе темы и сбрасывает кастомную пару.
      */
     setPair: (state, action: PayloadAction<ThemeVariant>) => {
       state.lightVariant = action.payload
@@ -59,7 +63,7 @@ const themeSlice = createSlice({
     },
 
     /**
-     * Расширенный режим: только светлая тема, тёмная не меняется.
+     * Расширенный режим: только светлая тема.
      */
     setLightVariant: (state, action: PayloadAction<ThemeVariant>) => {
       state.lightVariant = action.payload
@@ -68,7 +72,7 @@ const themeSlice = createSlice({
     },
 
     /**
-     * Расширенный режим: только тёмная тема, светлая не меняется.
+     * Расширенный режим: только тёмная тема.
      */
     setDarkVariant: (state, action: PayloadAction<ThemeVariant>) => {
       state.darkVariant = action.payload
@@ -77,15 +81,27 @@ const themeSlice = createSlice({
     },
 
     /**
-     * Переключение между светлым и тёмным режимом.
+     * Выбор режима темы: светлая / тёмная / системная.
+     * При system isDark будет обновлён ThemeProvider через prefers-color-scheme.
      */
-    toggleDark: (state) => {
-      state.isDark = !state.isDark
+    setThemeMode: (state, action: PayloadAction<ThemeMode>) => {
+      state.themeMode = action.payload
+      if (action.payload === 'light') state.isDark = false
+      if (action.payload === 'dark') state.isDark = true
       saveState({ ...state })
     },
 
     /**
-     * Явная установка режима (светлый/тёмный).
+     * Переключение light/dark — выходит из системного режима.
+     */
+    toggleDark: (state) => {
+      state.isDark = !state.isDark
+      state.themeMode = state.isDark ? 'dark' : 'light'
+      saveState({ ...state })
+    },
+
+    /**
+     * Прямая установка isDark — используется ThemeProvider для системного режима.
      */
     setDark: (state, action: PayloadAction<boolean>) => {
       state.isDark = action.payload
@@ -94,5 +110,6 @@ const themeSlice = createSlice({
   },
 })
 
-export const { setPair, setLightVariant, setDarkVariant, toggleDark, setDark } = themeSlice.actions
+export const { setPair, setLightVariant, setDarkVariant, setThemeMode, toggleDark, setDark } =
+  themeSlice.actions
 export default themeSlice.reducer

--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -237,6 +237,62 @@ $bp-md: 900px;
   letter-spacing: 0.06em;
 }
 
+// ─── Разделитель между блоками ────────────────────────────────────────────────
+
+.settings-divider {
+  border: none;
+  border-top: 1px solid var(--color-divider, #e0e0e0);
+  margin: 20px 0;
+}
+
+// ─── Метка блока настроек ─────────────────────────────────────────────────────
+
+.settings-block-label {
+  margin: 0 0 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-2, #666);
+}
+
+// ─── Цветовая схема (light / dark / system) ───────────────────────────────────
+
+.theme-color-mode {
+  display: flex;
+  gap: 8px;
+}
+
+.theme-color-mode__btn {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 8px;
+  border: 2px solid var(--color-divider, #e0e0e0);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+
+  &:hover {
+    border-color: var(--color-primary, #4e7b6a);
+    color: var(--color-text, inherit);
+  }
+
+  &--active {
+    border-color: var(--color-primary, #4e7b6a);
+    background: color-mix(in srgb, var(--color-primary, #4e7b6a) 10%, transparent);
+    color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 0 0 1px var(--color-primary, #4e7b6a);
+  }
+}
+
 // ─── Переключатель анимации ───────────────────────────────────────────────────
 
 .animation-row {
@@ -244,42 +300,37 @@ $bp-md: 900px;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  margin-top: 20px;
+  width: 100%;
+  margin-top: 12px;
   padding: 14px 16px;
   border-radius: 12px;
-  // Непрозрачный фон — частицы за блоком не просвечивают
   background: var(--color-paper, white);
   border: 1px solid var(--color-divider, #e0e0e0);
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
   position: relative;
   isolation: isolate;
-}
+  transition: border-color 0.15s;
 
-.animation-row__info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.animation-row__label {
-  font-size: 14px;
-  font-weight: 500;
-  color: var(--color-text, inherit);
+  &:hover {
+    border-color: var(--color-primary, #4e7b6a);
+  }
 }
 
 .animation-row__desc {
-  font-size: 12px;
-  color: var(--color-text-2, #666);
+  font-size: 13px;
+  color: var(--color-text, inherit);
 }
 
 .animation-toggle {
   width: 44px;
   height: 26px;
   border-radius: 999px;
-  border: none;
   background: var(--color-divider, #ccc);
   padding: 3px;
-  cursor: pointer;
   flex-shrink: 0;
+  pointer-events: none;
   position: relative;
   transition: background 0.2s;
 
@@ -304,6 +355,57 @@ $bp-md: 900px;
   }
 }
 
+// ─── Info-подсказка ───────────────────────────────────────────────────────────
+
+.info-hint {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-2, #999);
+  cursor: default;
+  margin-left: 6px;
+  padding: 2px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+
+  &:hover {
+    color: var(--color-primary, #4e7b6a);
+    background: color-mix(in srgb, var(--color-primary, #4e7b6a) 12%, transparent);
+  }
+
+  &:hover .info-hint__tooltip {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
+.info-hint__tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  width: 240px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: var(--color-text, #1e3328);
+  color: var(--color-paper, white);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.5;
+  text-transform: none;
+  letter-spacing: 0;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 10;
+  white-space: normal;
+
+  strong {
+    font-weight: 700;
+  }
+}
+
 // ─── Переключатель режима (простой / раздельный) ─────────────────────────────
 
 .theme-mode-header {
@@ -315,9 +417,13 @@ $bp-md: 900px;
 
 .theme-mode-label {
   margin: 0;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text, inherit);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-2, #666);
+  display: inline-flex;
+  align-items: center;
 }
 
 .theme-mode-toggle {
@@ -358,6 +464,12 @@ $bp-md: 900px;
   }
 }
 
+.theme-mode-btn__text {
+  @media (max-width: $bp-sm) {
+    display: none;
+  }
+}
+
 // ─── Секция тем (светлая / тёмная) ───────────────────────────────────────────
 
 .theme-section {
@@ -373,24 +485,11 @@ $bp-md: 900px;
 .theme-section__label {
   margin: 0;
   font-size: 12px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
+  font-weight: 500;
   color: var(--color-text-2, #666);
   display: flex;
   align-items: center;
   gap: 8px;
-}
-
-.theme-section__badge {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: 0;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--color-primary, #4e7b6a);
-  color: white;
 }
 
 // ─── Сетка тем ────────────────────────────────────────────────────────────────

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -5,18 +5,29 @@ import {
   Check,
   Palette,
   Settings,
-  Layers,
+  SlidersHorizontal,
   LayoutGrid,
+  Sun,
+  Moon,
+  Monitor,
+  Smartphone,
+  Info,
 } from 'lucide-react'
 import { useNavigate, useParams } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
-import { setPair, setLightVariant, setDarkVariant } from '@/features/theme'
+import { setPair, setLightVariant, setDarkVariant, setThemeMode } from '@/features/theme'
+import type { ThemeMode } from '@/features/theme'
 import { toggleParticles } from '@/features/animations'
 import { THEME_COLORS, LIGHT_THEMES, DARK_THEMES } from '@/shared/config/themes'
 import type { ThemeVariant } from '@/shared/config/themes'
 import styles from './SettingsPage.module.scss'
 
 const THEME_MODE_KEY = 'treqio_theme_picker_mode'
+
+function getSystemIcon() {
+  if (/mobile|android|iphone/i.test(navigator.userAgent)) return <Smartphone size={20} />
+  return <Monitor size={20} />
+}
 
 /**
  * Раздел настроек.
@@ -110,18 +121,26 @@ export function SettingsPage() {
  */
 function AppearanceContent() {
   const dispatch = useAppDispatch()
-  const { lightVariant, darkVariant, isDark } = useAppSelector((s) => s.theme)
+  const { lightVariant, darkVariant, isDark, themeMode } = useAppSelector((s) => s.theme)
   const particlesEnabled = useAppSelector((s) => s.animations.particlesEnabled)
   const activeVariant = isDark ? darkVariant : lightVariant
   const hasParticles = !!THEME_COLORS[activeVariant].particle
 
-  const [advancedMode, setAdvancedMode] = useState<boolean>(
-    () => localStorage.getItem(THEME_MODE_KEY) === 'advanced',
-  )
+  const [advancedMode, setAdvancedMode] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(THEME_MODE_KEY) === 'advanced'
+    } catch {
+      return false
+    }
+  })
 
   const handleModeChange = (mode: 'simple' | 'advanced') => {
     setAdvancedMode(mode === 'advanced')
-    localStorage.setItem(THEME_MODE_KEY, mode)
+    try {
+      localStorage.setItem(THEME_MODE_KEY, mode)
+    } catch {
+      // ignore storage errors
+    }
   }
 
   const handleSimpleSelect = (variant: ThemeVariant) => {
@@ -130,22 +149,56 @@ function AppearanceContent() {
 
   return (
     <>
+      {/* Режим темы */}
+      <p className={styles['settings-block-label']}>Цветовая схема</p>
+      <div className={styles['theme-color-mode']}>
+        {(
+          [
+            { mode: 'light', icon: <Sun size={20} />, label: 'Светлая' },
+            { mode: 'dark', icon: <Moon size={20} />, label: 'Тёмная' },
+            { mode: 'system', icon: getSystemIcon(), label: 'Системная' },
+          ] as { mode: ThemeMode; icon: React.ReactNode; label: string }[]
+        ).map(({ mode, icon, label }) => (
+          <button
+            key={mode}
+            className={`${styles['theme-color-mode__btn']} ${themeMode === mode ? styles['theme-color-mode__btn--active'] : ''}`}
+            onClick={() => dispatch(setThemeMode(mode))}
+          >
+            {icon}
+            <span>{label}</span>
+          </button>
+        ))}
+      </div>
+
+      <hr className={styles['settings-divider']} />
+
       <div className={styles['theme-mode-header']}>
-        <span className={styles['theme-mode-label']}>Тема оформления</span>
+        <span className={styles['theme-mode-label']}>
+          Тема оформления
+          <span className={styles['info-hint']}>
+            <Info size={16} />
+            <span className={styles['info-hint__tooltip']}>
+              У каждой темы есть светлая и тёмная версия. В <strong>простом</strong> режиме они
+              переключаются <strong>вместе</strong>. В <strong>расширенном</strong> режиме можно
+              выбрать светлую и тёмную версии из <strong>разных</strong> тем{' '}
+              <strong>независимо</strong>.
+            </span>
+          </span>
+        </span>
         <div className={styles['theme-mode-toggle']}>
           <button
             className={`${styles['theme-mode-btn']} ${!advancedMode ? styles['theme-mode-btn--active'] : ''}`}
             onClick={() => handleModeChange('simple')}
           >
             <LayoutGrid size={13} />
-            Простой
+            <span className={styles['theme-mode-btn__text']}>Простой</span>
           </button>
           <button
             className={`${styles['theme-mode-btn']} ${advancedMode ? styles['theme-mode-btn--active'] : ''}`}
             onClick={() => handleModeChange('advanced')}
           >
-            <Layers size={13} />
-            Расширенный
+            <SlidersHorizontal size={13} />
+            <span className={styles['theme-mode-btn__text']}>Расширенный</span>
           </button>
         </div>
       </div>
@@ -164,7 +217,10 @@ function AppearanceContent() {
       ) : (
         <>
           <div className={styles['theme-section']}>
-            <p className={styles['theme-section__label']}>Светлая тема</p>
+            <p className={styles['theme-section__label']}>
+              <Sun size={13} />
+              Светлая тема
+            </p>
             <div className={styles['theme-grid']}>
               {LIGHT_THEMES.map((t) => (
                 <ThemeCard
@@ -178,7 +234,10 @@ function AppearanceContent() {
           </div>
 
           <div className={styles['theme-section']}>
-            <p className={styles['theme-section__label']}>Тёмная тема</p>
+            <p className={styles['theme-section__label']}>
+              <Moon size={13} />
+              Тёмная тема
+            </p>
             <div className={styles['theme-grid']}>
               {DARK_THEMES.map((t) => (
                 <ThemeCard
@@ -194,19 +253,22 @@ function AppearanceContent() {
       )}
 
       {hasParticles && (
-        <div className={styles['animation-row']}>
-          <div className={styles['animation-row__info']}>
-            <span className={styles['animation-row__label']}>Анимация</span>
-            <span className={styles['animation-row__desc']}>Фоновая анимация</span>
-          </div>
+        <>
+          <hr className={styles['settings-divider']} />
+          <p className={styles['settings-block-label']}>Анимация</p>
           <button
-            className={`${styles['animation-toggle']} ${particlesEnabled ? styles['animation-toggle--on'] : ''}`}
+            className={styles['animation-row']}
             onClick={() => dispatch(toggleParticles())}
             aria-label={particlesEnabled ? 'Выключить анимацию' : 'Включить анимацию'}
           >
-            <span className={styles['animation-toggle__thumb']} />
+            <span className={styles['animation-row__desc']}>Фоновая анимация</span>
+            <span
+              className={`${styles['animation-toggle']} ${particlesEnabled ? styles['animation-toggle--on'] : ''}`}
+            >
+              <span className={styles['animation-toggle__thumb']} />
+            </span>
           </button>
-        </div>
+        </>
       )}
     </>
   )


### PR DESCRIPTION
## Summary

- Выбор цветовой схемы: Светлая / Тёмная / Системная (следит за prefers-color-scheme)
- Плитки с иконками Sun / Moon / Monitor|Smartphone по типу устройства
- При переключении кнопкой в сайдбаре — автоматический выход из системного режима
- Иконка SlidersHorizontal для расширенного режима вместо Layers
- Текст кнопок Простой/Расширенный скрыт на мобилке — только иконки
- Info-подсказка с выделением ключевых слов для блока «Тема оформления»
- Разделители между блоками настроек
- Рефакторинг: удалён мёртвый CSS-класс, localStorage обёрнут в try-catch

## Test plan

- [ ] Светлая / Тёмная / Системная — переключение работает
- [ ] Системная подхватывает тему ОС и реагирует на её смену
- [ ] Кнопка Sun/Moon в сайдбаре выходит из системного режима
- [ ] На мобилке в переключателе режима только иконки без текста
- [ ] Info-подсказка появляется при наведении на иконку