### PR TITLE
Добавление хлебных крошек в настройках

### DIFF
--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -42,13 +42,16 @@ $bp-md: 900px;
 }
 
 .settings__header {
-  padding: 12px 36px 10px;
+  height: 58px;
+  padding: 0 36px;
+  display: flex;
+  align-items: center;
   flex-shrink: 0;
   background: var(--color-chip-bg, #dff0e5);
   border-bottom: 1px solid var(--color-divider, #e0e0e0);
 
   @media (max-width: $bp-sm) {
-    padding: 10px 20px 8px;
+    padding: 0 20px;
   }
 }
 
@@ -64,10 +67,47 @@ $bp-md: 900px;
   gap: 12px;
 }
 
-.settings__title-icon {
+// ─── Хлебные крошки ───────────────────────────────────────────────────────────
+
+.settings__breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  background: color-mix(in srgb, var(--header-title-color, #243d35) 8%, transparent);
+  border: none;
+  padding: 4px 10px 4px 8px;
+  border-radius: 8px;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s;
+
+  &:hover {
+    background: color-mix(in srgb, var(--header-title-color, #243d35) 16%, transparent);
+  }
+}
+
+.settings__breadcrumb-static {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px 4px 8px;
+  font-size: inherit;
+  font-weight: inherit;
+  letter-spacing: inherit;
+  color: inherit;
+}
+
+.settings__breadcrumb-sep {
   color: var(--color-text-2, #666);
   flex-shrink: 0;
-  margin-right: -2px;
+  opacity: 0.5;
+}
+
+.settings__breadcrumb-current {
+  color: var(--color-text-2, #666);
+  font-weight: 500;
 }
 
 // ─── Тело страницы — список + контент ─────────────────────────────────────────

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -4,7 +4,6 @@ import {
   ChevronRight,
   Check,
   Palette,
-  Settings,
   SlidersHorizontal,
   LayoutGrid,
   Sun,
@@ -68,8 +67,22 @@ export function SettingsPage() {
     <div className={styles['settings']}>
       <div className={styles['settings__header']}>
         <h1 className={styles['settings__title']}>
-          Настройки
-          <Settings size={28} className={styles['settings__title-icon']} />
+          {active ? (
+            <button
+              className={styles['settings__breadcrumb']}
+              onClick={() => navigate('/settings')}
+            >
+              Настройки
+            </button>
+          ) : (
+            <span className={styles['settings__breadcrumb-static']}>Настройки</span>
+          )}
+          {active && (
+            <>
+              <ChevronRight size={14} className={styles['settings__breadcrumb-sep']} />
+              <span className={styles['settings__breadcrumb-current']}>{active.label}</span>
+            </>
+          )}
         </h1>
       </div>
 
@@ -99,10 +112,7 @@ export function SettingsPage() {
               <ChevronLeft size={16} />
               Назад
             </button>
-            <div className={styles['settings__section']}>
-              <p className={styles['settings__section-title']}>{active.label}</p>
-              {active.content}
-            </div>
+            <div className={styles['settings__section']}>{active.content}</div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

- Заголовок «Настройки» превращается в кликабельную крошку при открытом разделе
- Без выбранного раздела — просто текст, без кнопки и фона
- Убран дублирующий заголовок раздела внутри контента
- Фиксированная высота шапки — нет визуального сдвига при появлении крошек

## Test plan

- [ ] /settings — просто «Настройки», без кнопки
- [ ] /settings/appearance — крошки «Настройки › Внешний вид», клик по «Настройки» ведёт на /settings
- [ ] Высота шапки одинакова в обоих случаях