### PR TITLE
User profile backend

### DIFF
--- a/apps/api/prisma/migrations/20260512154815_make_username_displayname_optional_add_ispublic/migration.sql
+++ b/apps/api/prisma/migrations/20260512154815_make_username_displayname_optional_add_ispublic/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "isPublic" BOOLEAN NOT NULL DEFAULT true,
+ALTER COLUMN "username" DROP NOT NULL,
+ALTER COLUMN "displayName" DROP NOT NULL;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -13,18 +13,19 @@ datasource db {
 
 model User {
   // cuid() — непредсказуемый ID, защищает от перебора записей по числовому порядку
-  id          String   @id @default(cuid())
-  email       String   @unique // email используется для идентификации через OAuth
-  username    String   @unique // публичное имя пользователя в URL профиля
-  displayName String           // отображаемое имя (может содержать пробелы и спецсимволы)
-  avatarUrl   String?          // ссылка на аватар, берётся от OAuth-провайдера при регистрации
-  bio         String?          // краткое описание профиля, заполняется пользователем
+  id          String  @id @default(cuid())
+  email       String  @unique // email используется для идентификации через OAuth
+  username    String? @unique // публичное имя пользователя в URL профиля
+  displayName String?         // отображаемое имя (может содержать пробелы и спецсимволы)
+  avatarUrl   String?         // ссылка на аватар, берётся от OAuth-провайдера при регистрации
+  bio         String?         // краткое описание профиля, заполняется пользователем
+  isPublic    Boolean @default(true) // публичность профиля
 
   provider   String // OAuth-провайдер: 'google' | 'github'
   providerId String // ID пользователя на стороне провайдера
 
   createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt // обновляется автоматически при каждом изменении записи
+  updatedAt DateTime @updatedAt
 
   // Один провайдер не может иметь два одинаковых providerId
   @@unique([provider, providerId])

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,12 +3,13 @@ import { AppController } from './app.controller'
 import { AppService } from './app.service'
 import { PrismaModule } from './prisma/prisma.module'
 import { AuthModule } from './auth/auth.module'
+import { UsersModule } from './users/users.module'
 
 /**
  * Корневой модуль приложения.
  */
 @Module({
-  imports: [PrismaModule, AuthModule],
+  imports: [PrismaModule, AuthModule, UsersModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/users/dto/update-profile.dto.ts
+++ b/apps/api/src/users/dto/update-profile.dto.ts
@@ -1,0 +1,18 @@
+import { ApiPropertyOptional } from '@nestjs/swagger'
+
+/**
+ * Данные для обновления профиля пользователя.
+ */
+export class UpdateProfileDto {
+  @ApiPropertyOptional({ description: 'Отображаемое имя' })
+  displayName?: string
+
+  @ApiPropertyOptional({ description: 'Уникальный никнейм' })
+  username?: string
+
+  @ApiPropertyOptional({ description: 'Краткое описание профиля' })
+  bio?: string
+
+  @ApiPropertyOptional({ description: 'Публичность профиля' })
+  isPublic?: boolean
+}

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,38 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common'
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger'
+import type { Request } from 'express'
+import type { User } from '../generated/prisma/client'
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard'
+import { UpdateProfileDto } from './dto/update-profile.dto'
+import { UsersService } from './users.service'
+
+/**
+ * Контроллер управления профилем текущего пользователя.
+ */
+@ApiTags('users')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  /**
+   * Возвращает профиль авторизованного пользователя.
+   */
+  @ApiOperation({ summary: 'Получить профиль текущего пользователя' })
+  @Get('me')
+  getMe(@Req() req: Request): Promise<User> {
+    const user = req.user as User
+    return this.usersService.getProfile(user.id)
+  }
+
+  /**
+   * Обновляет профиль авторизованного пользователя.
+   */
+  @ApiOperation({ summary: 'Обновить профиль текущего пользователя' })
+  @Patch('me')
+  updateMe(@Req() req: Request, @Body() dto: UpdateProfileDto): Promise<User> {
+    const user = req.user as User
+    return this.usersService.updateProfile(user.id, dto)
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common'
+import { PrismaModule } from '../prisma/prisma.module'
+import { UsersController } from './users.controller'
+import { UsersService } from './users.service'
+
+/**
+ * Модуль управления профилями пользователей.
+ */
+@Module({
+  imports: [PrismaModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, ConflictException } from '@nestjs/common'
+import type { User } from '../generated/prisma/client'
+import { PrismaService } from '../prisma/prisma.service'
+import type { UpdateProfileDto } from './dto/update-profile.dto'
+
+/**
+ * Сервис управления профилем пользователя.
+ */
+@Injectable()
+export class UsersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Получение профиля по ID.
+   */
+  async getProfile(userId: string): Promise<User> {
+    return this.prisma.user.findUniqueOrThrow({ where: { id: userId } })
+  }
+
+  /**
+   * Обновление профиля пользователя.
+   */
+  async updateProfile(userId: string, dto: UpdateProfileDto): Promise<User> {
+    if (dto.username) {
+      const taken = await this.prisma.user.findUnique({
+        where: { username: dto.username },
+      })
+      if (taken && taken.id !== userId) {
+        throw new ConflictException('Никнейм уже занят')
+      }
+    }
+
+    return this.prisma.user.update({
+      where: { id: userId },
+      data: dto,
+    })
+  }
+}


### PR DESCRIPTION
## Summary

- Модель User расширена: `username` и `displayName` стали опциональными, добавлен `isPublic`
- Миграция применена к БД
- `GET /users/me` — возвращает профиль авторизованного пользователя
- `PATCH /users/me` — обновляет `displayName`, `username`, `bio`, `isPublic` с проверкой уникальности никнейма

## Test plan

- [ ] `GET /users/me` возвращает профиль текущего пользователя
- [ ] `PATCH /users/me` обновляет поля профиля
- [ ] `PATCH /users/me` с занятым `username` возвращает 409
- [ ] Swagger: `/api/docs` показывает новые эндпоинты