### PR TITLE
Редактирование имени профиля

### DIFF
--- a/apps/web/src/features/user/api/constraints.ts
+++ b/apps/web/src/features/user/api/constraints.ts
@@ -1,0 +1,15 @@
+/**
+ * Ограничения полей профиля — синхронизированы с backend DTO.
+ */
+
+/** Максимальная длина отображаемого имени. */
+export const DISPLAY_NAME_MAX = 50
+
+/** Минимальная длина никнейма. */
+export const USERNAME_MIN = 3
+
+/** Максимальная длина никнейма. */
+export const USERNAME_MAX = 30
+
+/** Максимальная длина bio. */
+export const BIO_MAX = 200

--- a/apps/web/src/features/user/index.ts
+++ b/apps/web/src/features/user/index.ts
@@ -1,2 +1,3 @@
 export { useGetMeQuery, useUpdateMeMutation } from './api/userApi'
 export type { UserProfile, UpdateProfileDto } from './api/userApi'
+export * from './api/constraints'

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -72,10 +72,13 @@ $bp-md: 900px;
   font-size: 24px;
   font-weight: 600;
   letter-spacing: -0.02em;
+  line-height: 1.2;
   color: var(--color-text, inherit);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
 
   @media (max-width: $bp-sm) {
     font-size: 18px;
@@ -89,6 +92,8 @@ $bp-md: 900px;
   align-items: center;
   gap: 6px;
   flex-wrap: wrap;
+  padding-left: 14px;
+  margin-top: 6px;
 }
 
 .header__bio {
@@ -100,6 +105,83 @@ $bp-md: 900px;
 
   @media (max-width: $bp-sm) {
     display: none;
+  }
+}
+
+// ─── Инлайн-редактирование имени ─────────────────────────────────────────────
+
+.name-field {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 36px;
+  width: 320px;
+  padding: 0 6px 0 14px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--color-primary, #4e7b6a) 8%, var(--color-paper-2, #f0f0f0));
+  border: 1px solid transparent;
+  transition: border-color 0.15s, box-shadow 0.15s;
+
+  &--editing {
+    border-color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary, #4e7b6a) 20%, transparent);
+  }
+
+  @media (max-width: $bp-sm) {
+    width: 240px;
+  }
+}
+
+.name-field__input {
+  flex: 1;
+  min-width: 0;
+  padding: 0;
+  margin: 0;
+  appearance: none;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  color: var(--color-text, inherit);
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: inherit;
+
+  @media (max-width: $bp-sm) {
+    font-size: 18px;
+  }
+}
+
+.name-field__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.name-field__btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: color-mix(in srgb, var(--color-primary, #4e7b6a) 12%, transparent);
+    color: var(--color-primary, #4e7b6a);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
-import { BookOpen, Gamepad2, Filter } from 'lucide-react'
-import { useGetMeQuery } from '@/features/user'
+import { useState, useRef, useEffect } from 'react'
+import { BookOpen, Gamepad2, Filter, Pencil, Check, X } from 'lucide-react'
+import { useGetMeQuery, useUpdateMeMutation } from '@/features/user'
+import { DISPLAY_NAME_MAX } from '@/features/user/api/constraints'
 import styles from './ProfilePage.module.scss'
 
 type Category = 'books' | 'games'
@@ -26,11 +27,41 @@ const GAME_STATUSES: { id: GameStatus; label: string }[] = [
  */
 export const ProfilePage = () => {
   const { data: user, isLoading } = useGetMeQuery()
+  const [updateMe, { isLoading: isSaving }] = useUpdateMeMutation()
   const [category, setCategory] = useState<Category>('books')
   const [bookStatus, setBookStatus] = useState<BookStatus>('want')
   const [gameStatus, setGameStatus] = useState<GameStatus>('want')
+  const [editingName, setEditingName] = useState(false)
+  const [nameValue, setNameValue] = useState('')
+  const nameInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (editingName) nameInputRef.current?.focus()
+  }, [editingName])
 
   if (isLoading) return null
+
+  /** Переходит в режим редактирования имени, заполняя поле текущим значением. */
+  const handleEditName = () => {
+    setNameValue(user?.username ?? '')
+    setEditingName(true)
+  }
+
+  /** Сохраняет новый username если он изменился и не пустой. */
+  const handleSaveName = async () => {
+    const trimmed = nameValue.trim()
+    if (!trimmed || trimmed === user?.username) {
+      setEditingName(false)
+      return
+    }
+    await updateMe({ username: trimmed })
+    setEditingName(false)
+  }
+
+  /** Отменяет редактирование без сохранения. */
+  const handleCancelName = () => {
+    setEditingName(false)
+  }
 
   const statuses = category === 'books' ? BOOK_STATUSES : GAME_STATUSES
   const activeStatus = category === 'books' ? bookStatus : gameStatus
@@ -39,9 +70,12 @@ export const ProfilePage = () => {
       ? (s: string) => setBookStatus(s as BookStatus)
       : (s: string) => setGameStatus(s as GameStatus)
 
+  /** Отображаемое имя — username, затем displayName, затем дефолт. */
   const rawName = user?.username || user?.displayName || 'Мечтатель'
-  const displayName = rawName.charAt(0).toUpperCase() + rawName.slice(1)
-  const avatarLetter = displayName.charAt(0).toUpperCase()
+  /** Итоговое отображаемое имя. */
+  const displayName = rawName
+  /** Первая буква имени для аватара-заглушки. */
+  const avatarLetter = rawName.charAt(0).toUpperCase()
 
   return (
     <div className={styles['profile']}>
@@ -50,7 +84,44 @@ export const ProfilePage = () => {
         <div className={styles['header__top']}>
           <div className={styles['avatar-placeholder']}>{avatarLetter}</div>
           <div className={styles['header__info']}>
-            <h1 className={styles['header__name']}>{displayName}</h1>
+            <div
+              className={`${styles['name-field']} ${editingName ? styles['name-field--editing'] : ''}`}
+            >
+              {editingName ? (
+                <>
+                  <input
+                    ref={nameInputRef}
+                    className={styles['name-field__input']}
+                    value={nameValue}
+                    onChange={(e) => setNameValue(e.target.value)}
+                    maxLength={DISPLAY_NAME_MAX}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleSaveName()
+                      if (e.key === 'Escape') handleCancelName()
+                    }}
+                  />
+                  <div className={styles['name-field__actions']}>
+                    <button className={styles['name-field__btn']} onClick={handleCancelName}>
+                      <X size={15} />
+                    </button>
+                    <button
+                      className={styles['name-field__btn']}
+                      onClick={handleSaveName}
+                      disabled={isSaving}
+                    >
+                      <Check size={15} />
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <h1 className={styles['header__name']}>{displayName}</h1>
+                  <button className={styles['name-field__btn']} onClick={handleEditName}>
+                    <Pencil size={14} />
+                  </button>
+                </>
+              )}
+            </div>
             <div className={styles['header__meta']}>
               {user?.username && <span>@{user.username}</span>}
             </div>


### PR DESCRIPTION
## Summary

- Инлайн-редактирование username прямо на странице профиля
- Поле фиксированной ширины с тематическим фоном — одинаково для всех пользователей
- В режиме редактирования: цветной бордер + свечение в цвет темы
- Кнопки ✕ и ✓ появляются на месте иконки карандаша
- Enter — сохранить, Escape — отмена, `maxLength` синхронизирован с backend
- Константы ограничений полей в `features/user/api/constraints.ts`

## Test plan

- [ ] Клик на карандаш открывает инпут с текущим username
- [ ] Enter сохраняет, Escape отменяет
- [ ] Пустое значение не сохраняется
- [ ] `maxLength` ограничивает ввод
- [ ] Поле выглядит одинаково в светлой и тёмной теме