### PR TITLE
Ограничение длины имени и счётчик символов

### DIFF
--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -73,7 +73,6 @@ export class AuthService {
     return this.prisma.user.create({
       data: {
         email: profile.email,
-        displayName: profile.displayName,
         username,
         avatarUrl: profile.avatarUrl,
         provider: 'google',

--- a/apps/api/src/users/dto/update-profile.dto.ts
+++ b/apps/api/src/users/dto/update-profile.dto.ts
@@ -2,7 +2,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger'
 import { IsBoolean, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator'
 
 /** Максимальная длина отображаемого имени. */
-export const DISPLAY_NAME_MAX = 50
+export const DISPLAY_NAME_MAX = 25
 
 /** Минимальная длина никнейма. */
 export const USERNAME_MIN = 3

--- a/apps/web/src/features/user/api/constraints.ts
+++ b/apps/web/src/features/user/api/constraints.ts
@@ -3,7 +3,7 @@
  */
 
 /** Максимальная длина отображаемого имени. */
-export const DISPLAY_NAME_MAX = 50
+export const DISPLAY_NAME_MAX = 25
 
 /** Минимальная длина никнейма. */
 export const USERNAME_MIN = 3

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -36,7 +36,6 @@ $bp-md: 900px;
 
 // ─── Аватар ───────────────────────────────────────────────────────────────────
 
-
 .avatar-placeholder {
   width: 80px;
   height: 80px;
@@ -65,6 +64,7 @@ $bp-md: 900px;
   gap: 4px;
   min-width: 0;
   flex: 1;
+  position: relative;
 }
 
 .header__name {
@@ -93,7 +93,7 @@ $bp-md: 900px;
   gap: 6px;
   flex-wrap: wrap;
   padding-left: 14px;
-  margin-top: 6px;
+  margin-top: 14px;
 }
 
 .header__bio {
@@ -116,11 +116,14 @@ $bp-md: 900px;
   gap: 6px;
   height: 36px;
   width: 320px;
+  position: relative;
   padding: 0 6px 0 14px;
   border-radius: 8px;
   background: color-mix(in srgb, var(--color-primary, #4e7b6a) 8%, var(--color-paper-2, #f0f0f0));
   border: 1px solid transparent;
-  transition: border-color 0.15s, box-shadow 0.15s;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
 
   &--editing {
     border-color: var(--color-primary, #4e7b6a);
@@ -172,7 +175,9 @@ $bp-md: 900px;
   color: var(--color-text-2, #666);
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 
   &:hover {
     background: color-mix(in srgb, var(--color-primary, #4e7b6a) 12%, transparent);
@@ -185,13 +190,32 @@ $bp-md: 900px;
   }
 }
 
+
+.name-counter {
+  position: absolute;
+  top: 26px;
+  right: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+
+  &--warn {
+    color: #f59e0b;
+  }
+
+  &--max {
+    color: #e05252;
+  }
+}
+
 // ─── Табы категорий ───────────────────────────────────────────────────────────
 
 .category-tabs {
   display: flex;
   gap: 4px;
   padding: 4px;
-  background: var(--color-paper-2, rgba(0,0,0,0.06));
+  background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
   border-radius: 12px;
   width: fit-content;
 
@@ -213,7 +237,9 @@ $bp-md: 900px;
   font-weight: 500;
   font-family: inherit;
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
   flex: 1;
   justify-content: center;
 
@@ -224,7 +250,7 @@ $bp-md: 900px;
   &--active {
     background: var(--color-paper, white);
     color: var(--color-primary, #4e7b6a);
-    box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   }
 }
 
@@ -258,7 +284,7 @@ $bp-md: 900px;
   text-align: left;
 
   &:hover {
-    background: var(--color-paper-2, rgba(0,0,0,0.04));
+    background: var(--color-paper-2, rgba(0, 0, 0, 0.04));
   }
 
   &--active .stat__value {
@@ -299,7 +325,9 @@ $bp-md: 900px;
   display: grid;
   place-items: center;
   cursor: pointer;
-  transition: border-color 0.15s, color 0.15s;
+  transition:
+    border-color 0.15s,
+    color 0.15s;
 
   &:hover {
     border-color: var(--color-primary, #4e7b6a);

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -41,21 +41,26 @@ export const ProfilePage = () => {
 
   if (isLoading) return null
 
-  /** Переходит в режим редактирования имени, заполняя поле текущим значением. */
+  /** Переходит в режим редактирования имени, заполняя поле тем что сейчас отображается. */
   const handleEditName = () => {
-    setNameValue(user?.username ?? '')
+    setNameValue(user?.displayName || user?.username || '')
     setEditingName(true)
   }
 
-  /** Сохраняет новый username если он изменился и не пустой. */
+  /** Сохраняет новое displayName если оно изменилось. */
   const handleSaveName = async () => {
     const trimmed = nameValue.trim()
-    if (!trimmed || trimmed === user?.username) {
+    const current = user?.displayName || user?.username || ''
+    if (!trimmed || trimmed === current) {
       setEditingName(false)
       return
     }
-    await updateMe({ username: trimmed })
-    setEditingName(false)
+    try {
+      await updateMe({ displayName: trimmed }).unwrap()
+      setEditingName(false)
+    } catch {
+      setEditingName(false)
+    }
   }
 
   /** Отменяет редактирование без сохранения. */
@@ -65,17 +70,17 @@ export const ProfilePage = () => {
 
   const statuses = category === 'books' ? BOOK_STATUSES : GAME_STATUSES
   const activeStatus = category === 'books' ? bookStatus : gameStatus
-  const setStatus =
-    category === 'books'
-      ? (s: string) => setBookStatus(s as BookStatus)
-      : (s: string) => setGameStatus(s as GameStatus)
 
-  /** Отображаемое имя — username, затем displayName, затем дефолт. */
-  const rawName = user?.username || user?.displayName || 'Мечтатель'
-  /** Итоговое отображаемое имя. */
-  const displayName = rawName
+  /** Переключает активный статус в текущей категории. */
+  const handleStatusChange = (id: string) => {
+    if (category === 'books') setBookStatus(id as BookStatus)
+    else setGameStatus(id as GameStatus)
+  }
+
+  /** Отображаемое имя — displayName если задан, иначе username, иначе дефолт. */
+  const displayName = user?.displayName || user?.username || 'Мечтатель'
   /** Первая буква имени для аватара-заглушки. */
-  const avatarLetter = rawName.charAt(0).toUpperCase()
+  const avatarLetter = displayName.charAt(0).toUpperCase()
 
   return (
     <div className={styles['profile']}>
@@ -121,6 +126,18 @@ export const ProfilePage = () => {
                   </button>
                 </>
               )}
+              {editingName && nameValue.length >= DISPLAY_NAME_MAX - 5 && (
+                <p
+                  className={[
+                    styles['name-counter'],
+                    nameValue.length >= DISPLAY_NAME_MAX
+                      ? styles['name-counter--max']
+                      : styles['name-counter--warn'],
+                  ].join(' ')}
+                >
+                  {nameValue.length}/{DISPLAY_NAME_MAX}
+                </p>
+              )}
             </div>
             <div className={styles['header__meta']}>
               {user?.username && <span>@{user.username}</span>}
@@ -153,7 +170,7 @@ export const ProfilePage = () => {
             <button
               key={s.id}
               className={`${styles['stat']} ${activeStatus === s.id ? styles['stat--active'] : ''}`}
-              onClick={() => setStatus(s.id)}
+              onClick={() => handleStatusChange(s.id)}
             >
               <span className={styles['stat__value']}>0</span>
               <span className={styles['stat__label']}>{s.label}</span>


### PR DESCRIPTION
## Summary

- `DISPLAY_NAME_MAX` = 25 символов (синхронизировано в frontend и backend)
- Счётчик `X/25` появляется когда осталось менее 5 символов
- Янтарный цвет при приближении к лимиту, красный при достижении
- `displayName` и `username` — независимые поля, редактирование имени не меняет @никнейм
- При регистрации через Google `displayName` больше не берётся из Google-аккаунта
- Рефакторинг: `setStatus` → `handleStatusChange`, вынесен className счётчика

## Test plan

- [ ] Имя и @никнейм независимы — редактирование одного не меняет другой
- [ ] Счётчик появляется при 20+ символах
- [ ] При 25/25 счётчик становится красным, ввод заблокирован
- [ ] Новый пользователь видит username, а не Google-имя