### PR TITLE
feat(web): гостевой режим — вход, маршруты и профиль

### DIFF
--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -10,10 +10,10 @@ import { useAppSelector } from '@/shared/lib/store'
 import { AppLayout } from '@/widgets/layout'
 
 /**
- * Защита приватных роутов — редирект на /login если пользователь не авторизован.
+ * Пропускает авторизованных пользователей и гостей, остальных редиректит на /login.
  */
 function RequireAuth() {
-  const { accessToken, isInitialized } = useAppSelector((s) => s.auth)
+  const { accessToken, isGuest, isInitialized } = useAppSelector((s) => s.auth)
 
   // Ждём завершения проверки сессии в AuthProvider перед редиректом
   if (!isInitialized) {
@@ -26,7 +26,7 @@ function RequireAuth() {
     )
   }
 
-  if (!accessToken) {
+  if (!accessToken && !isGuest) {
     return <Navigate to="/login" replace />
   }
 

--- a/apps/web/src/app/store.ts
+++ b/apps/web/src/app/store.ts
@@ -1,5 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit'
 import { authReducer } from '@/features/auth'
+import { guestReducer } from '@/features/guest'
 import { themeReducer } from '@/features/theme'
 import { layoutReducer } from '@/features/layout'
 import { animationsReducer } from '@/features/animations'
@@ -11,6 +12,7 @@ import { baseApi } from '@/shared/api/baseApi'
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    guest: guestReducer,
     theme: themeReducer,
     layout: layoutReducer,
     animations: animationsReducer,

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,2 +1,2 @@
 export { default as authReducer } from './model/authSlice'
-export { setCredentials, setUser, logout, setInitialized } from './model/authSlice'
+export { setCredentials, setUser, enterAsGuest, logout, setInitialized } from './model/authSlice'

--- a/apps/web/src/features/auth/model/authSlice.ts
+++ b/apps/web/src/features/auth/model/authSlice.ts
@@ -2,6 +2,8 @@ import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 import type { User } from '@/entities/user'
 
+const GUEST_KEY = 'treqio_guest'
+
 /**
  * Состояние авторизации в Redux store.
  */
@@ -12,13 +14,16 @@ interface AuthState {
   accessToken: string | null
   /** Флаг завершения начальной проверки сессии. */
   isInitialized: boolean
+  /** Пользователь вошёл как гость без регистрации. */
+  isGuest: boolean
 }
 
-/** Начальное состояние. */
+/** Начальное состояние — восстанавливаем гостевой режим из localStorage. */
 const initialState: AuthState = {
   user: null,
   accessToken: null,
   isInitialized: false,
+  isGuest: localStorage.getItem(GUEST_KEY) === 'true',
 }
 
 /**
@@ -33,6 +38,8 @@ const authSlice = createSlice({
      */
     setCredentials: (state, action: PayloadAction<{ accessToken: string; user?: User }>) => {
       state.accessToken = action.payload.accessToken
+      state.isGuest = false
+      localStorage.removeItem(GUEST_KEY)
       if (action.payload.user) {
         state.user = action.payload.user
       }
@@ -46,11 +53,23 @@ const authSlice = createSlice({
     },
 
     /**
+     * Вход в гостевой режим без регистрации.
+     */
+    enterAsGuest: (state) => {
+      state.isGuest = true
+      state.user = null
+      state.accessToken = null
+      localStorage.setItem(GUEST_KEY, 'true')
+    },
+
+    /**
      * Очистка сессии при выходе из системы.
      */
     logout: (state) => {
       state.user = null
       state.accessToken = null
+      state.isGuest = false
+      localStorage.removeItem(GUEST_KEY)
     },
 
     /**
@@ -62,6 +81,6 @@ const authSlice = createSlice({
   },
 })
 
-export const { setCredentials, setUser, logout, setInitialized } = authSlice.actions
+export const { setCredentials, setUser, enterAsGuest, logout, setInitialized } = authSlice.actions
 
 export default authSlice.reducer

--- a/apps/web/src/features/guest/index.ts
+++ b/apps/web/src/features/guest/index.ts
@@ -1,0 +1,1 @@
+export { default as guestReducer, setGuestDisplayName, clearGuestProfile } from './model/guestSlice'

--- a/apps/web/src/features/guest/model/guestSlice.ts
+++ b/apps/web/src/features/guest/model/guestSlice.ts
@@ -1,0 +1,54 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+
+const STORAGE_KEY = 'treqio_guest_profile'
+
+/**
+ * Профиль гостевого пользователя, хранимый в localStorage.
+ */
+interface GuestProfile {
+  /** Отображаемое имя, заданное гостем. */
+  displayName: string | null
+}
+
+function loadProfile(): GuestProfile {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (raw) return JSON.parse(raw) as GuestProfile
+  } catch {
+    // ignore parse errors
+  }
+  return { displayName: null }
+}
+
+function saveProfile(profile: GuestProfile) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(profile))
+}
+
+/**
+ * Slice данных гостевого пользователя.
+ */
+const guestSlice = createSlice({
+  name: 'guest',
+  initialState: loadProfile,
+  reducers: {
+    /**
+     * Обновление отображаемого имени гостя.
+     */
+    setGuestDisplayName: (state, action: PayloadAction<string>) => {
+      state.displayName = action.payload
+      saveProfile({ ...state })
+    },
+
+    /**
+     * Сброс данных гостя при выходе или входе в аккаунт.
+     */
+    clearGuestProfile: (state) => {
+      state.displayName = null
+      localStorage.removeItem(STORAGE_KEY)
+    },
+  },
+})
+
+export const { setGuestDisplayName, clearGuestProfile } = guestSlice.actions
+export default guestSlice.reducer

--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
 import type { CSSProperties } from 'react'
-import { Button, Tooltip, useMediaQuery } from '@mui/material'
+import { Button, useMediaQuery } from '@mui/material'
 import { Activity, BarChart2, LibraryBig } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import { useAppDispatch } from '@/shared/lib/store'
+import { enterAsGuest } from '@/features/auth'
 import styles from './LoginPage.module.scss'
 
 const API_URL = import.meta.env['VITE_API_URL'] as string
@@ -48,9 +51,17 @@ const FEATURES = [
  */
 export function LoginPage() {
   const isMobile = useMediaQuery('(max-width:599px)')
+  const dispatch = useAppDispatch()
+  const navigate = useNavigate()
 
   const handleGoogleLogin = () => {
     window.location.href = `${API_URL}/auth/google`
+  }
+
+  /** Вход в гостевой режим без регистрации. */
+  const handleGuestLogin = () => {
+    dispatch(enterAsGuest())
+    navigate('/')
   }
 
   const cardsRef = useRef<HTMLDivElement>(null)
@@ -100,18 +111,16 @@ export function LoginPage() {
             <span className={styles['login-page__or-line']} />
           </div>
 
-          <Tooltip title="Гостевой режим — скоро" placement="bottom" arrow>
-            <span className={styles['login-page__guest-btn-wrapper']}>
-              <Button
-                variant="outlined"
-                size="large"
-                disabled
-                className={styles['login-page__guest-btn']}
-              >
-                Продолжить без входа
-              </Button>
-            </span>
-          </Tooltip>
+          <span className={styles['login-page__guest-btn-wrapper']}>
+            <Button
+              variant="outlined"
+              size="large"
+              onClick={handleGuestLogin}
+              className={styles['login-page__guest-btn']}
+            >
+              Продолжить без входа
+            </Button>
+          </span>
 
           <p className={styles['login-page__hint']}>Без входа данные хранятся только в браузере</p>
         </div>

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -2,7 +2,11 @@ import { useState, useRef, useEffect } from 'react'
 import { BookOpen, Gamepad2, Filter, Pencil, Check, X } from 'lucide-react'
 import { useGetMeQuery, useUpdateMeMutation } from '@/features/user'
 import { DISPLAY_NAME_MAX } from '@/features/user/api/constraints'
+import { setGuestDisplayName } from '@/features/guest'
+import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import styles from './ProfilePage.module.scss'
+
+const DEFAULT_DISPLAY_NAME = 'Мечтатель'
 
 type Category = 'books' | 'games'
 type BookStatus = 'want' | 'reading' | 'done' | 'dropped'
@@ -26,7 +30,10 @@ const GAME_STATUSES: { id: GameStatus; label: string }[] = [
  * Страница профиля пользователя.
  */
 export const ProfilePage = () => {
-  const { data: user, isLoading } = useGetMeQuery()
+  const dispatch = useAppDispatch()
+  const isGuest = useAppSelector((s) => s.auth.isGuest)
+  const guestDisplayName = useAppSelector((s) => s.guest.displayName)
+  const { data: user, isLoading } = useGetMeQuery(undefined, { skip: isGuest })
   const [updateMe, { isLoading: isSaving }] = useUpdateMeMutation()
   const [category, setCategory] = useState<Category>('books')
   const [bookStatus, setBookStatus] = useState<BookStatus>('want')
@@ -43,15 +50,25 @@ export const ProfilePage = () => {
 
   /** Переходит в режим редактирования имени, заполняя поле тем что сейчас отображается. */
   const handleEditName = () => {
-    setNameValue(user?.displayName || user?.username || '')
+    const current = isGuest
+      ? guestDisplayName || DEFAULT_DISPLAY_NAME
+      : user?.displayName || user?.username || ''
+    setNameValue(current)
     setEditingName(true)
   }
 
   /** Сохраняет новое displayName если оно изменилось. */
   const handleSaveName = async () => {
     const trimmed = nameValue.trim()
-    const current = user?.displayName || user?.username || ''
+    const current = isGuest
+      ? guestDisplayName || DEFAULT_DISPLAY_NAME
+      : user?.displayName || user?.username || ''
     if (!trimmed || trimmed === current) {
+      setEditingName(false)
+      return
+    }
+    if (isGuest) {
+      dispatch(setGuestDisplayName(trimmed))
       setEditingName(false)
       return
     }
@@ -78,7 +95,9 @@ export const ProfilePage = () => {
   }
 
   /** Отображаемое имя — displayName если задан, иначе username, иначе дефолт. */
-  const displayName = user?.displayName || user?.username || 'Мечтатель'
+  const displayName = isGuest
+    ? guestDisplayName || DEFAULT_DISPLAY_NAME
+    : user?.displayName || user?.username || DEFAULT_DISPLAY_NAME
   /** Первая буква имени для аватара-заглушки. */
   const avatarLetter = displayName.charAt(0).toUpperCase()
 

--- a/apps/web/src/shared/api/baseApi.ts
+++ b/apps/web/src/shared/api/baseApi.ts
@@ -24,6 +24,13 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
   api,
   extraOptions,
 ) => {
+  const { accessToken } = (api.getState() as RootState).auth
+
+  // если гость — возвращаем пустой результат без ошибки
+  if (!accessToken) {
+    return { data: null }
+  }
+
   let result = await baseQuery(args, api, extraOptions)
 
   if (result.error?.status === 401) {
@@ -34,8 +41,8 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
     )
 
     if (refreshResult.data) {
-      const { accessToken } = refreshResult.data as { accessToken: string }
-      api.dispatch(setCredentials({ accessToken }))
+      const { accessToken: newToken } = refreshResult.data as { accessToken: string }
+      api.dispatch(setCredentials({ accessToken: newToken }))
       result = await baseQuery(args, api, extraOptions)
     } else {
       api.dispatch(logout())


### PR DESCRIPTION
## Что сделано

- `authSlice` — добавлено состояние `isGuest`, экшен `enterAsGuest`, восстановление из localStorage при загрузке
- `RequireAuth` — гости проходят без редиректа на `/login`
- `LoginPage` — кнопка «Продолжить без входа» активирует гостевой режим
- `baseApi` — гости не делают API-запросы, возвращается пустой результат
- `guestSlice` — хранит `displayName` гостя в localStorage
- `store` — `guestReducer` зарегистрирован
- `ProfilePage` — читает и сохраняет имя гостя через `guestSlice`, не вызывает API