### PR TITLE
feat(web): баннер-подсказка для гостя и карточка в настройках

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -35,7 +35,7 @@ export const ThemeProvider = ({ children }: Props) => {
 
   useEffect(() => {
     const root = document.documentElement
-    const { sidebar, primary, divider, text, background } = theme.palette
+    const { sidebar, primary, warning, divider, text, background } = theme.palette
 
     // Токены активной темы — используются во всём приложении
     root.style.setProperty('--sidebar-bg', sidebar.background)
@@ -51,6 +51,10 @@ export const ThemeProvider = ({ children }: Props) => {
     root.style.setProperty('--color-text-2', text.secondary)
     root.style.setProperty('--color-paper', background.paper)
     root.style.setProperty('--color-paper-2', background.default)
+
+    root.style.setProperty('--color-warning', warning.main)
+    root.style.setProperty('--color-warning-bg', warning.main + '26') // 15% opacity
+    root.style.setProperty('--color-warning-border', warning.main + '59') // 35% opacity
 
     root.style.setProperty('--color-chip-bg', primary.light + '33')
     root.style.setProperty('--color-chip-text', primary.dark)

--- a/apps/web/src/features/guest/index.ts
+++ b/apps/web/src/features/guest/index.ts
@@ -1,1 +1,2 @@
 export { default as guestReducer, setGuestDisplayName, clearGuestProfile } from './model/guestSlice'
+export { GuestBanner } from './ui/GuestBanner/GuestBanner'

--- a/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
+++ b/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { Snackbar, Alert, Button, IconButton } from '@mui/material'
+import { X } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import { useAppSelector } from '@/shared/lib/store'
+
+const DISMISSED_KEY = 'treqio_guest_banner_dismissed'
+
+/**
+ * Баннер-подсказка для гостевого режима.
+ */
+export const GuestBanner = () => {
+  const isGuest = useAppSelector((s) => s.auth.isGuest)
+  const navigate = useNavigate()
+  const [dismissed, setDismissed] = useState(() => localStorage.getItem(DISMISSED_KEY) === 'true')
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISSED_KEY, 'true')
+    setDismissed(true)
+  }
+
+  return (
+    <Snackbar
+      open={isGuest && !dismissed}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+    >
+      <Alert
+        severity="warning"
+        action={
+          <>
+            <Button
+              size="small"
+              onClick={() => navigate('/login')}
+              sx={{
+                color: 'warning.main',
+                border: '1px solid',
+                borderColor: 'warning.main',
+                borderRadius: 1,
+                px: 1.5,
+              }}
+            >
+              Войти
+            </Button>
+            <IconButton size="small" color="inherit" onClick={handleDismiss} sx={{ ml: 1 }}>
+              <X size={16} />
+            </IconButton>
+          </>
+        }
+        sx={{ backdropFilter: 'blur(8px)', backgroundColor: 'var(--color-warning-bg)' }}
+      >
+        Данные хранятся только в браузере
+      </Alert>
+    </Snackbar>
+  )
+}

--- a/apps/web/src/pages/settings/SettingsPage.module.scss
+++ b/apps/web/src/pages/settings/SettingsPage.module.scss
@@ -639,3 +639,78 @@ $bp-md: 900px;
   color: var(--color-primary, #4e7b6a);
   font-weight: 600;
 }
+
+// ─── Карточка гостя ───────────────────────────────────────────────────────────
+
+.guest-card {
+  margin: 20px 24px;
+  padding: 10px 20px;
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  animation: rise 0.3s ease both;
+
+  @media (max-width: $bp-sm) {
+    margin: 16px;
+  }
+}
+
+.guest-card__left {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.guest-card__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.guest-card__title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text, inherit);
+}
+
+.guest-card__sub {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: var(--color-text-2, #666);
+}
+
+.guest-card__btn {
+  display: inline-flex;
+  align-items: center;
+  padding: 7px 16px;
+  border: 1px solid var(--color-warning);
+  border-radius: 8px;
+  background: none;
+  color: var(--color-warning);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+  transition: background 0.15s;
+
+  &:hover {
+    background: var(--color-warning-bg);
+  }
+
+  @media (max-width: $bp-sm) {
+    padding: 7px 12px;
+  }
+}

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -3,6 +3,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Check,
+  TriangleAlert,
   Palette,
   SlidersHorizontal,
   LayoutGrid,
@@ -50,6 +51,7 @@ interface SettingsSection {
 export function SettingsPage() {
   const { section } = useParams<{ section: string }>()
   const navigate = useNavigate()
+  const isGuest = useAppSelector((s) => s.auth.isGuest)
 
   const sections: SettingsSection[] = [
     {
@@ -117,9 +119,26 @@ export function SettingsPage() {
         )}
 
         {!active && (
-          <div
-            className={`${styles['settings__content']} ${styles['settings__content--hidden']}`}
-          />
+          <div className={`${styles['settings__content']} ${styles['settings__content--hidden']}`}>
+            {isGuest && (
+              <div className={styles['guest-card']}>
+                <div className={styles['guest-card__left']}>
+                  <div className={styles['guest-card__icon']}>
+                    <TriangleAlert size={18} />
+                  </div>
+                  <div>
+                    <p className={styles['guest-card__title']}>Войдите</p>
+                    <p className={styles['guest-card__sub']}>
+                      Чтобы не потерять данные и иметь доступ с любого устройства
+                    </p>
+                  </div>
+                </div>
+                <button className={styles['guest-card__btn']} onClick={() => navigate('/login')}>
+                  Войти
+                </button>
+              </div>
+            )}
+          </div>
         )}
       </div>
     </div>

--- a/apps/web/src/widgets/layout/AppLayout.tsx
+++ b/apps/web/src/widgets/layout/AppLayout.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router'
 import { useAppSelector } from '@/shared/lib/store'
 import { THEME_COLORS } from '@/shared/config/themes'
 import { ParticleCanvas } from '@/features/animations'
+import { GuestBanner } from '@/features/guest'
 import { Sidebar } from './Sidebar'
 import { MobileNav } from './MobileNav'
 
@@ -59,6 +60,7 @@ export const AppLayout = () => {
         }}
       >
         {showParticles && <ParticleCanvas type={particleType!} />}
+        <GuestBanner />
         <Outlet />
       </Box>
 


### PR DESCRIPTION
## Что сделано

- `GuestBanner` — Snackbar с Alert (severity warning) в нижней части экрана для гостей
- Кнопка «Войти» ведёт на страницу входа, крестик скрывает баннер навсегда (localStorage)
- `ThemeProvider` — добавлены CSS-переменные `--color-warning`, `--color-warning-bg`, `--color-warning-border` из `theme.palette.warning.main`
- `AppLayout` — `GuestBanner` подключён один раз для всех страниц
- `SettingsPage` — карточка-подсказка для гостя на главной странице настроек в едином стиле с баннером