### PR TITLE
feat(web): кнопки входа и выхода в профиле

### DIFF
--- a/apps/web/src/features/user/api/userApi.ts
+++ b/apps/web/src/features/user/api/userApi.ts
@@ -38,17 +38,32 @@ export interface UpdateProfileDto {
   isPublic?: boolean
 }
 
+/**
+ * API пользователя.
+ */
 export const userApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
+    /**
+     * Получение профиля текущего пользователя.
+     */
     getMe: build.query<UserProfile, void>({
       query: () => '/users/me',
       providesTags: ['User'],
     }),
+    /**
+     * Обновление профиля текущего пользователя.
+     */
     updateMe: build.mutation<UserProfile, UpdateProfileDto>({
       query: (body) => ({ url: '/users/me', method: 'PATCH', body }),
       invalidatesTags: ['User'],
     }),
+    /**
+     * Выход из системы.
+     */
+    logout: build.mutation<void, void>({
+      query: () => ({ url: '/auth/logout', method: 'POST' }),
+    }),
   }),
 })
 
-export const { useGetMeQuery, useUpdateMeMutation } = userApi
+export const { useGetMeQuery, useUpdateMeMutation, useLogoutMutation } = userApi

--- a/apps/web/src/features/user/index.ts
+++ b/apps/web/src/features/user/index.ts
@@ -1,3 +1,3 @@
-export { useGetMeQuery, useUpdateMeMutation } from './api/userApi'
+export { useGetMeQuery, useUpdateMeMutation, useLogoutMutation } from './api/userApi'
 export type { UserProfile, UpdateProfileDto } from './api/userApi'
 export * from './api/constraints'

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -34,6 +34,31 @@ $bp-md: 900px;
   }
 }
 
+.header__auth-btn {
+  margin-left: auto;
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-paper);
+  color: var(--color-primary);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    background: var(--color-chip-bg);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  }
+}
+
 // ─── Аватар ───────────────────────────────────────────────────────────────────
 
 .avatar-placeholder {

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -1,8 +1,10 @@
 import { useState, useRef, useEffect } from 'react'
-import { BookOpen, Gamepad2, Filter, Pencil, Check, X } from 'lucide-react'
-import { useGetMeQuery, useUpdateMeMutation } from '@/features/user'
+import { BookOpen, Gamepad2, Filter, Pencil, Check, X, LogIn, LogOut } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import { useGetMeQuery, useUpdateMeMutation, useLogoutMutation } from '@/features/user'
 import { DISPLAY_NAME_MAX } from '@/features/user/api/constraints'
 import { setGuestDisplayName } from '@/features/guest'
+import { logout } from '@/features/auth'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import styles from './ProfilePage.module.scss'
 
@@ -31,10 +33,21 @@ const GAME_STATUSES: { id: GameStatus; label: string }[] = [
  */
 export const ProfilePage = () => {
   const dispatch = useAppDispatch()
+  const navigate = useNavigate()
   const isGuest = useAppSelector((s) => s.auth.isGuest)
   const guestDisplayName = useAppSelector((s) => s.guest.displayName)
   const { data: user, isLoading } = useGetMeQuery(undefined, { skip: isGuest })
   const [updateMe, { isLoading: isSaving }] = useUpdateMeMutation()
+  const [logoutMutation] = useLogoutMutation()
+
+  /**
+   * Функция выхода из аккаунта.
+   */
+  const handleLogout = async () => {
+    await logoutMutation()
+    dispatch(logout())
+    navigate('/login')
+  }
   const [category, setCategory] = useState<Category>('books')
   const [bookStatus, setBookStatus] = useState<BookStatus>('want')
   const [gameStatus, setGameStatus] = useState<GameStatus>('want')
@@ -42,13 +55,18 @@ export const ProfilePage = () => {
   const [nameValue, setNameValue] = useState('')
   const nameInputRef = useRef<HTMLInputElement>(null)
 
+  /**
+   * Фокусировка поля ввода при открытии редактора имени.
+   */
   useEffect(() => {
     if (editingName) nameInputRef.current?.focus()
   }, [editingName])
 
   if (isLoading) return null
 
-  /** Переходит в режим редактирования имени, заполняя поле тем что сейчас отображается. */
+  /**
+   * Функция редактирования имени пользователя.
+   */
   const handleEditName = () => {
     const current = isGuest
       ? guestDisplayName || DEFAULT_DISPLAY_NAME
@@ -57,16 +75,20 @@ export const ProfilePage = () => {
     setEditingName(true)
   }
 
-  /** Сохраняет новое displayName если оно изменилось. */
+  /**
+   * Функция сохранения имени пользователя.
+   */
   const handleSaveName = async () => {
     const trimmed = nameValue.trim()
     const current = isGuest
       ? guestDisplayName || DEFAULT_DISPLAY_NAME
       : user?.displayName || user?.username || ''
+    // Если пустое значение или имя не изменилось
     if (!trimmed || trimmed === current) {
       setEditingName(false)
       return
     }
+    // Если гость - сохраняем локально без запроса к API
     if (isGuest) {
       dispatch(setGuestDisplayName(trimmed))
       setEditingName(false)
@@ -80,7 +102,9 @@ export const ProfilePage = () => {
     }
   }
 
-  /** Отменяет редактирование без сохранения. */
+  /**
+   * Функция отмены редактирования имени.
+   */
   const handleCancelName = () => {
     setEditingName(false)
   }
@@ -88,17 +112,17 @@ export const ProfilePage = () => {
   const statuses = category === 'books' ? BOOK_STATUSES : GAME_STATUSES
   const activeStatus = category === 'books' ? bookStatus : gameStatus
 
-  /** Переключает активный статус в текущей категории. */
+  /**
+   * Функция переключения статуса в текущей категории.
+   */
   const handleStatusChange = (id: string) => {
     if (category === 'books') setBookStatus(id as BookStatus)
     else setGameStatus(id as GameStatus)
   }
 
-  /** Отображаемое имя — displayName если задан, иначе username, иначе дефолт. */
   const displayName = isGuest
     ? guestDisplayName || DEFAULT_DISPLAY_NAME
     : user?.displayName || user?.username || DEFAULT_DISPLAY_NAME
-  /** Первая буква имени для аватара-заглушки. */
   const avatarLetter = displayName.charAt(0).toUpperCase()
 
   return (
@@ -163,6 +187,13 @@ export const ProfilePage = () => {
             </div>
             {user?.bio && <p className={styles['header__bio']}>{user.bio}</p>}
           </div>
+          <button
+            className={styles['header__auth-btn']}
+            onClick={isGuest ? () => navigate('/login') : handleLogout}
+          >
+            {isGuest ? <LogIn size={15} /> : <LogOut size={15} />}
+            {isGuest ? 'Войти' : 'Выйти'}
+          </button>
         </div>
 
         {/* Табы категорий */}


### PR DESCRIPTION
## Что сделано

- `userApi` — добавлена мутация `logout` (POST /auth/logout), сбрасывает httpOnly cookie на сервере
- `ProfilePage` — кнопка в шапке профиля: «Войти» для гостя, «Выйти» для авторизованного пользователя
- При выходе — вызов API, очистка store, редирект на `/login`