### PR TITLE
feat(api): prisma schema — book and book-entry models

### DIFF
--- a/apps/api/prisma/migrations/20260520172834_add_book_and_book_entry/migration.sql
+++ b/apps/api/prisma/migrations/20260520172834_add_book_and_book_entry/migration.sql
@@ -1,0 +1,43 @@
+-- CreateEnum
+CREATE TYPE "BookStatus" AS ENUM ('WANT', 'READING', 'DONE', 'DROPPED');
+
+-- CreateTable
+CREATE TABLE "Book" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "author" TEXT NOT NULL,
+    "coverUrl" TEXT,
+    "description" TEXT,
+    "pageCount" INTEGER,
+    "genres" TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Book_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BookEntry" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "bookId" TEXT NOT NULL,
+    "status" "BookStatus" NOT NULL,
+    "rating" INTEGER,
+    "progress" INTEGER,
+    "startDate" TIMESTAMP(3),
+    "finishDate" TIMESTAMP(3),
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BookEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BookEntry_userId_bookId_key" ON "BookEntry"("userId", "bookId");
+
+-- AddForeignKey
+ALTER TABLE "BookEntry" ADD CONSTRAINT "BookEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BookEntry" ADD CONSTRAINT "BookEntry_bookId_fkey" FOREIGN KEY ("bookId") REFERENCES "Book"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -11,22 +11,98 @@ datasource db {
   // URL подключения берётся из prisma.config.ts → process.env["DATABASE_URL"]
 }
 
+/// Пользователь приложения.
 model User {
-  // cuid() — непредсказуемый ID, защищает от перебора записей по числовому порядку
+  /// Уникальный идентификатор.
   id          String  @id @default(cuid())
-  email       String  @unique // email используется для идентификации через OAuth
-  username    String? @unique // публичное имя пользователя в URL профиля
-  displayName String?         // отображаемое имя (может содержать пробелы и спецсимволы)
-  avatarUrl   String?         // ссылка на аватар, берётся от OAuth-провайдера при регистрации
-  bio         String?         // краткое описание профиля, заполняется пользователем
-  isPublic    Boolean @default(true) // публичность профиля
+  /// Email адрес — используется для идентификации через OAuth.
+  email       String  @unique
+  /// Публичное имя пользователя в URL профиля.
+  username    String? @unique
+  /// Отображаемое имя — может содержать пробелы и спецсимволы.
+  displayName String?
+  /// Ссылка на аватар — берётся от OAuth-провайдера при регистрации.
+  avatarUrl   String?
+  /// Краткое описание профиля.
+  bio         String?
+  /// Флаг публичности профиля.
+  isPublic    Boolean @default(true)
 
-  provider   String // OAuth-провайдер: 'google' | 'github'
-  providerId String // ID пользователя на стороне провайдера
+  /// OAuth-провайдер: 'google' | 'github'.
+  provider   String
+  /// Идентификатор пользователя на стороне провайдера.
+  providerId String
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  // Один провайдер не может иметь два одинаковых providerId
+  bookEntries BookEntry[]
+
   @@unique([provider, providerId])
+}
+
+/// Статус книги в списке пользователя.
+enum BookStatus {
+  /// Хочу прочитать.
+  WANT
+  /// Читаю.
+  READING
+  /// Прочитал.
+  DONE
+  /// Брошено.
+  DROPPED
+}
+
+/// Книга в общей библиотеке приложения.
+model Book {
+  /// Уникальный идентификатор.
+  id          String   @id @default(cuid())
+  /// Название книги.
+  title       String
+  /// Автор книги.
+  author      String
+  /// URL обложки.
+  coverUrl    String?
+  /// Описание книги.
+  description String?
+  /// Количество страниц.
+  pageCount   Int?
+  /// Жанры книги.
+  genres      String[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  entries BookEntry[]
+}
+
+/// Запись пользователя по конкретной книге.
+model BookEntry {
+  /// Уникальный идентификатор.
+  id         String     @id @default(cuid())
+  /// Идентификатор пользователя.
+  userId     String
+  /// Идентификатор книги.
+  bookId     String
+  /// Статус книги в списке пользователя.
+  status     BookStatus
+  /// Оценка от 1 до 10.
+  rating     Int?
+  /// Текущая страница.
+  progress   Int?
+  /// Дата начала чтения.
+  startDate  DateTime?
+  /// Дата завершения чтения.
+  finishDate DateTime?
+  /// Заметки пользователя.
+  notes      String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  book Book @relation(fields: [bookId], references: [id], onDelete: Cascade)
+
+  /// Одна запись на пользователя на книгу.
+  @@unique([userId, bookId])
 }


### PR DESCRIPTION
## Что сделано

- Модель `Book` — глобальная запись книги (title, author, coverUrl, description, pageCount, genres)
- Модель `BookEntry` — персональная запись пользователя (status, rating, progress, startDate, finishDate, notes)
- Enum `BookStatus` — WANT / READING / DONE / DROPPED
- Связи: `User → BookEntry → Book`, уникальный constraint `[userId, bookId]`
- Миграция применена
- Документационные комментарии `///` на всех моделях и полях