### PR TITLE
feat(web): unit-тест guest-slice (#106)

### DIFF
--- a/apps/web/src/features/guest/model/guestSlice.test.ts
+++ b/apps/web/src/features/guest/model/guestSlice.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { guestReducer, setGuestDisplayName } from '..'
+import { GUEST_STORAGE_KEY } from '../model/guestSlice'
+
+describe('guestSlice', () => {
+  it('начальное состояние - displayName равно null', () => {
+    const result = guestReducer(undefined, { type: '' })
+    expect(result.displayName).toBeNull()
+  })
+
+  it('setGuestDisplayName сохраняет имя в state и localStorage', () => {
+    const userName = 'user name'
+    const state = guestReducer(undefined, setGuestDisplayName(userName))
+
+    const raw = localStorage.getItem(GUEST_STORAGE_KEY)
+    const stored = JSON.parse(raw!)
+    expect(stored.displayName).toBe(userName)
+    expect(state.displayName).toBe(userName)
+  })
+})

--- a/apps/web/src/features/guest/model/guestSlice.ts
+++ b/apps/web/src/features/guest/model/guestSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
 
-const STORAGE_KEY = 'treqio_guest_profile'
+export const GUEST_STORAGE_KEY = 'treqio_guest_profile'
 
 /**
  * Профиль гостевого пользователя, хранимый в localStorage.
@@ -13,7 +13,7 @@ interface GuestProfile {
 
 function loadProfile(): GuestProfile {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY)
+    const raw = localStorage.getItem(GUEST_STORAGE_KEY)
     if (raw) return JSON.parse(raw) as GuestProfile
   } catch {
     // ignore parse errors
@@ -22,7 +22,7 @@ function loadProfile(): GuestProfile {
 }
 
 function saveProfile(profile: GuestProfile) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(profile))
+  localStorage.setItem(GUEST_STORAGE_KEY, JSON.stringify(profile))
 }
 
 /**
@@ -45,7 +45,7 @@ const guestSlice = createSlice({
      */
     clearGuestProfile: (state) => {
       state.displayName = null
-      localStorage.removeItem(STORAGE_KEY)
+      localStorage.removeItem(GUEST_STORAGE_KEY)
     },
   },
 })


### PR DESCRIPTION
## Что сделано

- Переименована константа `STORAGE_KEY` → `GUEST_STORAGE_KEY` и добавлен экспорт (нужен для импорта в тесте)
- Написан unit-тест для редьюсера `guestSlice`

## Тесты

- Начальное состояние: `displayName` равен `null`
- `setGuestDisplayName` сохраняет имя в state и в localStorage (проверяем через `JSON.parse`)

## Файлы

- `apps/web/src/features/guest/model/guestSlice.ts`
- `apps/web/src/features/guest/model/guestSlice.test.ts`