### PR TITLE
feat(web): компонентный тест guest-banner (#107)

### DIFF
--- a/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.test.tsx
+++ b/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router'
+import { configureStore } from '@reduxjs/toolkit'
+import { authReducer } from '@/features/auth'
+import { guestReducer } from '@/features/guest'
+import { themeReducer } from '@/features/theme'
+import { layoutReducer } from '@/features/layout'
+import { animationsReducer } from '@/features/animations'
+import { baseApi } from '@/shared/api/baseApi'
+import { GuestBanner } from './GuestBanner'
+
+/**
+ * Тестовый store с управляемым начальным состоянием.
+ * preloadedState переопределяет инициализацию authSlice из localStorage.
+ */
+const makeStore = (isGuest: boolean) =>
+  configureStore({
+    reducer: {
+      auth: authReducer,
+      guest: guestReducer,
+      theme: themeReducer,
+      layout: layoutReducer,
+      animations: animationsReducer,
+      [baseApi.reducerPath]: baseApi.reducer,
+    },
+    middleware: (m) => m().concat(baseApi.middleware),
+    preloadedState: {
+      auth: {
+        user: null,
+        accessToken: null,
+        isInitialized: true,
+        isGuest,
+      },
+    },
+  })
+
+/**
+ * Рендер GuestBanner с необходимыми провайдерами.
+ * Provider даёт компоненту доступ к store, MemoryRouter — к useNavigate.
+ */
+const renderBanner = (isGuest: boolean) =>
+  render(
+    <Provider store={makeStore(isGuest)}>
+      <MemoryRouter>
+        <GuestBanner />
+      </MemoryRouter>
+    </Provider>,
+  )
+
+describe('GuestBanner', () => {
+  // GuestBanner читает localStorage при монтировании — очищаем между тестами
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('показывает баннер если пользователь является гостем', () => {
+    renderBanner(true)
+    expect(screen.getByText('Данные хранятся только в браузере')).toBeInTheDocument()
+    expect(screen.getByText('Войти')).toBeInTheDocument()
+  })
+
+  it('не показывает баннер для авторизованного пользователя', () => {
+    renderBanner(false)
+    // queryByText возвращает null если элемент не найден
+    expect(screen.queryByText('Данные хранятся только в браузере')).not.toBeInTheDocument()
+  })
+
+  it('скрывает баннер и сохраняет флаг в localStorage при нажатии крестика', async () => {
+    renderBanner(true)
+    fireEvent.click(screen.getByRole('button', { name: 'Закрыть' }))
+
+    // Snackbar удаляет содержимое из DOM после анимации закрытия — ждём завершения
+    await waitFor(() => {
+      expect(screen.queryByText('Данные хранятся только в браузере')).not.toBeInTheDocument()
+    })
+
+    expect(localStorage.getItem('treqio_guest_banner_dismissed')).toBe('true')
+  })
+})

--- a/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
+++ b/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
@@ -23,6 +23,7 @@ export const GuestBanner = () => {
     <Snackbar
       open={isGuest && !dismissed}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      TransitionProps={{ unmountOnExit: true }}
     >
       <Alert
         severity="warning"
@@ -41,7 +42,13 @@ export const GuestBanner = () => {
             >
               Войти
             </Button>
-            <IconButton size="small" color="inherit" onClick={handleDismiss} sx={{ ml: 1 }}>
+            <IconButton
+              size="small"
+              color="inherit"
+              aria-label="Закрыть"
+              onClick={handleDismiss}
+              sx={{ ml: 1 }}
+            >
               <X size={16} />
             </IconButton>
           </>


### PR DESCRIPTION
## Что сделано

- Добавлен `aria-label="Закрыть"` на кнопку-крестик (доступность + возможность найти по роли в тестах)
- Добавлен `TransitionProps={{ unmountOnExit: true }}` в Snackbar (удаляет содержимое из DOM после анимации закрытия)
- Написан компонентный тест для `GuestBanner`

## Тесты

- Баннер показывается когда пользователь — гость
- Баннер не показывается для авторизованного пользователя
- Нажатие крестика скрывает баннер и сохраняет флаг в localStorage

## Файлы

- `apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx`
- `apps/web/src/features/guest/ui/GuestBanner/GuestBanner.test.tsx`