### PR TITLE
feat(web): компонент book-card (#112)

### DIFF
--- a/apps/web/src/entities/book/index.ts
+++ b/apps/web/src/entities/book/index.ts
@@ -1,0 +1,3 @@
+export { BookCard } from './ui/BookCard/BookCard'
+export { BookCoverCard } from './ui/BookCoverCard/BookCoverCard'
+export type { Book, BookEntry, BookStatus } from './model/book.types'

--- a/apps/web/src/entities/book/model/book.types.ts
+++ b/apps/web/src/entities/book/model/book.types.ts
@@ -1,0 +1,54 @@
+/**
+ * Статус книги в списке пользователя.
+ */
+export type BookStatus = 'WANT' | 'READING' | 'DONE' | 'DROPPED'
+
+/**
+ * Книга из общего каталога.
+ */
+export interface Book {
+  /** Уникальный идентификатор. */
+  id: string
+  /** Название книги. */
+  title: string
+  /** Автор книги. */
+  author: string
+  /** URL обложки. */
+  coverUrl: string | null
+  /** Описание книги. */
+  description: string | null
+  /** Количество страниц. */
+  pageCount: number | null
+  /** Жанры книги. */
+  genres: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+/**
+ * Запись пользователя по конкретной книге.
+ */
+export interface BookEntry {
+  /** Уникальный идентификатор. */
+  id: string
+  /** Идентификатор пользователя. */
+  userId: string
+  /** Идентификатор книги. */
+  bookId: string
+  /** Статус книги в списке пользователя. */
+  status: BookStatus
+  /** Оценка от 1 до 10. */
+  rating: number | null
+  /** Текущая страница. */
+  progress: number | null
+  /** Дата начала чтения. */
+  startDate: string | null
+  /** Дата завершения чтения. */
+  finishDate: string | null
+  /** Заметки пользователя. */
+  notes: string | null
+  createdAt: string
+  updatedAt: string
+  /** Данные книги (включаются при запросе). */
+  book: Book
+}

--- a/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
@@ -1,0 +1,141 @@
+import { Card, CardContent, CardMedia, Box, Typography, Chip } from '@mui/material'
+import { lighten, darken } from '@mui/material/styles'
+import { BookOpen, Star } from 'lucide-react'
+import type { BookEntry, BookStatus } from '../../model/book.types'
+
+const COVER_HEIGHT = 170
+
+const STATUS_LABEL: Record<BookStatus, string> = {
+  WANT: 'Хочу прочитать',
+  READING: 'Читаю',
+  DONE: 'Прочитал',
+  DROPPED: 'Брошено',
+}
+
+const STATUS_COLOR: Record<BookStatus, 'default' | 'info' | 'success' | 'error'> = {
+  WANT: 'default',
+  READING: 'info',
+  DONE: 'success',
+  DROPPED: 'error',
+}
+
+/**
+ * Пропсы BookCard.
+ */
+interface BookCardProps {
+  /** Запись пользователя с данными книги. */
+  entry: BookEntry
+}
+
+/**
+ * Карточка книги для отображения в библиотеке.
+ */
+export const BookCard = ({ entry }: BookCardProps) => {
+  const { book, status, rating } = entry
+
+  return (
+    <Card
+      sx={(theme) => ({
+        width: 160,
+        bgcolor: 'background.paper',
+        cursor: 'pointer',
+        transition: 'box-shadow 0.2s, transform 0.2s, border-color 0.2s',
+        boxShadow:
+          theme.palette.mode === 'dark'
+            ? '0px 2px 6px rgba(0,0,0,0.5)'
+            : '0px 2px 6px rgba(0,0,0,0.1)',
+        '&:hover': {
+          // Тень от наведения слабо заметна на любом фоне (особенно тёмном),
+          // поэтому основной сигнал — это подсветка рамки акцентным цветом
+          // и небольшой подъём карточки, а не сама тень.
+          transform: 'translateY(-3px)',
+          borderColor: 'primary.main',
+          boxShadow:
+            theme.palette.mode === 'dark'
+              ? '0px 6px 14px rgba(0,0,0,0.6)'
+              : '0px 6px 14px rgba(0,0,0,0.2)',
+        },
+      })}
+    >
+      {book.coverUrl ? (
+        <CardMedia
+          component="img"
+          image={book.coverUrl}
+          alt={book.title}
+          sx={{ height: COVER_HEIGHT, objectFit: 'cover' }}
+        />
+      ) : (
+        <Box
+          sx={(theme) => ({
+            height: COVER_HEIGHT,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            // Фон плейсхолдера считаем от цвета самой карточки, а не берём
+            // готовый токен темы — так гарантированный контраст с CardContent
+            // есть в любой из 12 палитр, а не только там где divider удачно лёг.
+            bgcolor:
+              theme.palette.mode === 'dark'
+                ? lighten(theme.palette.background.paper, 0.12)
+                : darken(theme.palette.background.paper, 0.05),
+            color: 'text.disabled',
+          })}
+        >
+          <BookOpen size={48} strokeWidth={1} />
+        </Box>
+      )}
+
+      <CardContent sx={{ p: 1.5, '&:last-child': { pb: 0.75 } }}>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            fontWeight: 600,
+            overflow: 'hidden',
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            lineHeight: 1.3,
+            // Резервируем высоту ровно на 2 строки независимо от длины названия —
+            // иначе короткие названия в одну строку сдвигают автора и статус выше,
+            // и карточки с разными названиями выглядят по-разному.
+            minHeight: '2.6em',
+            mb: 0.5,
+          }}
+        >
+          {book.title}
+        </Typography>
+
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          noWrap
+          sx={{ display: 'block', mb: 1 }}
+        >
+          {book.author}
+        </Typography>
+
+        <Box
+          sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 0.5 }}
+        >
+          <Chip label={STATUS_LABEL[status]} color={STATUS_COLOR[status]} size="small" />
+          {rating !== null && (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.25,
+                color: 'warning.main',
+                flexShrink: 0,
+              }}
+            >
+              <Star size={12} fill="currentColor" />
+              <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                {rating}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
@@ -1,0 +1,191 @@
+.cover-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 170px;
+  cursor: pointer;
+}
+
+// ─── Обложка ──────────────────────────────────────────────────────────────────
+
+.cover-card__cover {
+  position: relative;
+  aspect-ratio: 2 / 3;
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--color-primary, #4e7b6a);
+  box-shadow: 0 10px 24px -12px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 14px 13px;
+  transition: transform 0.22s cubic-bezier(0.2, 0.7, 0.3, 1), box-shadow 0.22s;
+
+  // Линия корешка
+  &::before {
+    content: '';
+    position: absolute;
+    left: 8px;
+    top: 10px;
+    bottom: 10px;
+    width: 2px;
+    background: rgba(255, 255, 255, 0.18);
+    border-radius: 2px;
+  }
+
+  // Лёгкая текстура бумаги
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(120% 80% at 100% 0%, rgba(255, 255, 255, 0.12), transparent 55%);
+    pointer-events: none;
+  }
+
+  .cover-card:hover & {
+    transform: translateY(-4px);
+    box-shadow: 0 18px 32px -14px rgba(0, 0, 0, 0.55);
+  }
+}
+
+.cover-card__title {
+  position: relative;
+  z-index: 1;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.2;
+  color: #fff;
+  letter-spacing: -0.01em;
+  text-shadow: 0 1px 10px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+
+.cover-card__author {
+  position: relative;
+  z-index: 1;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.75);
+  margin-top: 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// ─── Круглый бейдж оценки ─────────────────────────────────────────────────────
+
+.cover-card__score {
+  position: absolute;
+  top: 9px;
+  right: 9px;
+  z-index: 2;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 20, 18, 0.55);
+  backdrop-filter: blur(6px);
+}
+
+.cover-card__score-ring {
+  position: absolute;
+  inset: 0;
+  transform: rotate(-90deg);
+}
+
+.cover-card__score-value {
+  font-size: 12px;
+  font-weight: 700;
+  color: #fff;
+  line-height: 1;
+
+  &--empty {
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 14px;
+  }
+}
+
+// ─── Подпись под обложкой ─────────────────────────────────────────────────────
+
+.cover-card__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.cover-card__footer-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--color-text, inherit);
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+
+.cover-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  align-self: flex-start;
+  padding: 4px 10px 4px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.cover-card__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.cover-card__status--reading {
+  background: rgba(90, 160, 200, 0.16);
+  color: #4a92bd;
+
+  .cover-card__status-dot { background: #5aa0c8; }
+}
+
+.cover-card__status--done {
+  background: color-mix(in oklab, var(--color-primary, #4e7b6a) 16%, transparent);
+  color: var(--color-primary-dark, #3d6a55);
+
+  .cover-card__status-dot { background: var(--color-primary, #4e7b6a); }
+}
+
+.cover-card__status--want {
+  background: rgba(140, 140, 140, 0.16);
+  color: var(--color-text-2, #777);
+
+  .cover-card__status-dot { background: #999; }
+}
+
+.cover-card__status--dropped {
+  background: rgba(185, 64, 64, 0.14);
+  color: #b94040;
+
+  .cover-card__status-dot { background: #b94040; }
+}
+
+// ─── Прогресс чтения ──────────────────────────────────────────────────────────
+
+.cover-card__progress {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--color-paper-2, #ecf1ea);
+  overflow: hidden;
+}
+
+.cover-card__progress-bar {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: #5aa0c8;
+}

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -1,0 +1,118 @@
+import type { BookEntry, BookStatus } from '../../model/book.types'
+import styles from './BookCoverCard.module.scss'
+
+const STATUS_LABEL: Record<BookStatus, string> = {
+  WANT: 'Хочу прочитать',
+  READING: 'Читаю',
+  DONE: 'Прочитал',
+  DROPPED: 'Брошено',
+}
+
+const STATUS_CLASS: Record<BookStatus, string | undefined> = {
+  WANT: styles['cover-card__status--want'],
+  READING: styles['cover-card__status--reading'],
+  DONE: styles['cover-card__status--done'],
+  DROPPED: styles['cover-card__status--dropped'],
+}
+
+/** Цвет кольца и числа в бейдже оценки — по диапазону. */
+function scoreColor(rating: number): string {
+  if (rating >= 8) return 'var(--color-primary, #4e7b6a)'
+  if (rating >= 6) return 'var(--color-warning, #c49a3a)'
+  return '#b94040'
+}
+
+/**
+ * Круглый бейдж с оценкой (или плейсхолдер если книга не оценена).
+ */
+function ScoreBadge({ rating }: { rating: number | null }) {
+  if (rating === null) {
+    return (
+      <div className={styles['cover-card__score']}>
+        <span
+          className={`${styles['cover-card__score-value']} ${styles['cover-card__score-value--empty']}`}
+        >
+          +
+        </span>
+      </div>
+    )
+  }
+
+  const radius = 14
+  const circumference = 2 * Math.PI * radius
+  const offset = circumference * (1 - rating / 10)
+  const color = scoreColor(rating)
+
+  return (
+    <div className={styles['cover-card__score']} title={`Оценка ${rating}/10`}>
+      <svg className={styles['cover-card__score-ring']} width="34" height="34" viewBox="0 0 34 34">
+        <circle
+          cx="17"
+          cy="17"
+          r={radius}
+          fill="none"
+          stroke="rgba(255,255,255,0.18)"
+          strokeWidth="3"
+        />
+        <circle
+          cx="17"
+          cy="17"
+          r={radius}
+          fill="none"
+          stroke={color}
+          strokeWidth="3"
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+        />
+      </svg>
+      <span className={styles['cover-card__score-value']}>{rating}</span>
+    </div>
+  )
+}
+
+/**
+ * Пропсы BookCoverCard.
+ */
+interface BookCoverCardProps {
+  /** Запись пользователя с данными книги. */
+  entry: BookEntry
+}
+
+/**
+ * Карточка книги в стиле «обложка» — альтернативный вид BookCard.
+ */
+export const BookCoverCard = ({ entry }: BookCoverCardProps) => {
+  const { book, status, rating, progress } = entry
+
+  const progressPct =
+    status === 'READING' && progress !== null && book.pageCount
+      ? Math.min(100, Math.round((progress / book.pageCount) * 100))
+      : null
+
+  return (
+    <div className={styles['cover-card']}>
+      <div className={styles['cover-card__cover']}>
+        <ScoreBadge rating={rating} />
+        <div className={styles['cover-card__title']}>{book.title}</div>
+        <div className={styles['cover-card__author']}>{book.author}</div>
+      </div>
+
+      <div className={styles['cover-card__footer']}>
+        <p className={styles['cover-card__footer-title']}>{book.title}</p>
+        <span className={`${styles['cover-card__status']} ${STATUS_CLASS[status]}`}>
+          <span className={styles['cover-card__status-dot']} />
+          {STATUS_LABEL[status]}
+        </span>
+        {progressPct !== null && (
+          <div className={styles['cover-card__progress']}>
+            <span
+              className={styles['cover-card__progress-bar']}
+              style={{ width: `${progressPct}%` }}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
+++ b/apps/web/src/features/guest/ui/GuestBanner/GuestBanner.tsx
@@ -23,7 +23,7 @@ export const GuestBanner = () => {
     <Snackbar
       open={isGuest && !dismissed}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      TransitionProps={{ unmountOnExit: true }}
+      slotProps={{ transition: { unmountOnExit: true } }}
     >
       <Alert
         severity="warning"

--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -1,0 +1,105 @@
+$bp-sm: 600px;
+
+@keyframes rise {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+// ─── Страница ─────────────────────────────────────────────────────────────────
+
+.library {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+}
+
+// ─── Шапка ────────────────────────────────────────────────────────────────────
+
+.library__header {
+  padding: 28px 36px 12px;
+
+  @media (max-width: $bp-sm) {
+    padding: 20px 20px 10px;
+  }
+}
+
+.library__title {
+  margin: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text, inherit);
+  animation: rise 0.6s ease both;
+
+  @media (min-width: $bp-sm) {
+    font-size: 30px;
+  }
+}
+
+// ─── Лейбл-строка и переключатель стиля карточек ─────────────────────────────
+
+.library__label-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 36px 8px;
+
+  @media (max-width: $bp-sm) {
+    padding: 0 20px 8px;
+  }
+}
+
+.library__label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-2, #666);
+}
+
+.library__style-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+
+.library__style-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.06);
+    color: var(--color-text, inherit);
+  }
+
+  &--active {
+    background: var(--color-paper, white);
+    color: var(--color-primary, #4e7b6a);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+  }
+}
+
+// ─── Сетка карточек ───────────────────────────────────────────────────────────
+
+.library__grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  padding: 12px 36px 36px;
+
+  @media (max-width: $bp-sm) {
+    padding: 10px 20px 24px;
+  }
+}

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -1,7 +1,125 @@
-import { Box, Typography } from '@mui/material'
+import { useState } from 'react'
+import { LayoutGrid, Image } from 'lucide-react'
+import { BookCard, BookCoverCard, type BookEntry } from '@/entities/book'
+import styles from './LibraryPage.module.scss'
 
-export const LibraryPage = () => (
-  <Box sx={{ p: 4 }}>
-    <Typography variant="h4">Моя библиотека</Typography>
-  </Box>
-)
+/** Стиль отображения карточек книги. */
+type CardStyle = 'compact' | 'cover'
+
+const MOCK_ENTRIES: BookEntry[] = [
+  {
+    id: '1',
+    userId: '1',
+    bookId: '1',
+    status: 'READING',
+    rating: null,
+    progress: 120,
+    startDate: '2026-01-01',
+    finishDate: null,
+    notes: null,
+    createdAt: '',
+    updatedAt: '',
+    book: {
+      id: '1',
+      title: 'Мастер и Маргарита',
+      author: 'Михаил Булгаков',
+      coverUrl: null,
+      description: null,
+      pageCount: 480,
+      genres: ['Роман'],
+      createdAt: '',
+      updatedAt: '',
+    },
+  },
+  {
+    id: '2',
+    userId: '1',
+    bookId: '2',
+    status: 'DONE',
+    rating: 9,
+    progress: null,
+    startDate: '2025-12-01',
+    finishDate: '2026-01-15',
+    notes: null,
+    createdAt: '',
+    updatedAt: '',
+    book: {
+      id: '2',
+      title: 'Преступление и наказание',
+      author: 'Фёдор Достоевский',
+      coverUrl: null,
+      description: null,
+      pageCount: 592,
+      genres: ['Роман'],
+      createdAt: '',
+      updatedAt: '',
+    },
+  },
+  {
+    id: '3',
+    userId: '1',
+    bookId: '3',
+    status: 'WANT',
+    rating: null,
+    progress: null,
+    startDate: null,
+    finishDate: null,
+    notes: null,
+    createdAt: '',
+    updatedAt: '',
+    book: {
+      id: '3',
+      title: 'Война и мир',
+      author: 'Лев Толстой',
+      coverUrl: null,
+      description: null,
+      pageCount: 1225,
+      genres: ['Роман'],
+      createdAt: '',
+      updatedAt: '',
+    },
+  },
+]
+
+export const LibraryPage = () => {
+  const [cardStyle, setCardStyle] = useState<CardStyle>('compact')
+
+  return (
+    <div className={styles.library}>
+      <div className={styles['library__header']}>
+        <h1 className={styles['library__title']}>Моя библиотека</h1>
+      </div>
+
+      <div className={styles['library__label-row']}>
+        <span className={styles['library__label']}>{MOCK_ENTRIES.length} книг</span>
+
+        <div className={styles['library__style-toggle']}>
+          <button
+            className={`${styles['library__style-btn']} ${cardStyle === 'compact' ? styles['library__style-btn--active'] : ''}`}
+            onClick={() => setCardStyle('compact')}
+            title="Компактный вид"
+          >
+            <LayoutGrid size={16} />
+          </button>
+          <button
+            className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
+            onClick={() => setCardStyle('cover')}
+            title="Вид обложками"
+          >
+            <Image size={16} />
+          </button>
+        </div>
+      </div>
+
+      <div className={styles['library__grid']}>
+        {MOCK_ENTRIES.map((entry) =>
+          cardStyle === 'compact' ? (
+            <BookCard key={entry.id} entry={entry} />
+          ) : (
+            <BookCoverCard key={entry.id} entry={entry} />
+          ),
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Что сделано
- `entities/book` — типы `Book`/`BookEntry`/`BookStatus`, зеркало Prisma-схемы
- `BookCard` — компактная карточка (обложка/плейсхолдер, название, автор, статус, оценка)
- `BookCoverCard` — второй стиль карточки (обложка-постер одним цветом, круглый бейдж оценки, статус, прогресс-бар для «Читаю»)
- `LibraryPage` — переключатель между двумя стилями, заголовок в стиле главной страницы
- Попутный фикс: `GuestBanner.tsx` — `TransitionProps` заменён на `slotProps` (убрано в MUI v9)

## Проверка
- `npx tsc --noEmit` — чисто
- `npx vitest run` — 4 файла, 12 тестов, все проходят