### PR TITLE
feat(web): rtk query для книг (#114)

### DIFF
--- a/apps/web/src/features/book/api/booksApi.ts
+++ b/apps/web/src/features/book/api/booksApi.ts
@@ -1,0 +1,135 @@
+import { baseApi } from '@/shared/api/baseApi'
+import type { Book, BookEntry, BookStatus } from '@/entities/book'
+
+/**
+ * Данные для создания книги.
+ */
+export interface CreateBookDto {
+  /** Название книги. */
+  title: string
+  /** Автор книги. */
+  author: string
+  /** URL обложки. */
+  coverUrl?: string
+  /** Описание книги. */
+  description?: string
+  /** Количество страниц. */
+  pageCount?: number
+  /** Жанры книги. */
+  genres?: string[]
+}
+
+/**
+ * Данные для обновления книги — все поля необязательны.
+ */
+export type UpdateBookDto = Partial<CreateBookDto>
+
+/**
+ * Данные для добавления книги в список пользователя.
+ */
+export interface CreateBookEntryDto {
+  /** Идентификатор книги. */
+  bookId: string
+  /** Начальный статус книги. */
+  status: BookStatus
+}
+
+/**
+ * Данные для обновления записи о книге пользователя.
+ */
+export interface UpdateBookEntryDto {
+  /** Статус книги в списке. */
+  status?: BookStatus
+  /** Оценка от 1 до 10. */
+  rating?: number
+  /** Текущая страница. */
+  progress?: number
+  /** Дата начала чтения. */
+  startDate?: string
+  /** Дата завершения чтения. */
+  finishDate?: string
+  /** Заметки пользователя. */
+  notes?: string
+}
+
+/**
+ * API книг и записей пользователя.
+ */
+export const booksApi = baseApi.injectEndpoints({
+  endpoints: (build) => ({
+    /**
+     * Список всех книг каталога.
+     */
+    getBooks: build.query<Book[], void>({
+      query: () => '/books',
+      providesTags: ['Book'],
+    }),
+
+    /**
+     * Записи текущего пользователя (с вложенными данными книги).
+     */
+    getMyEntries: build.query<BookEntry[], void>({
+      query: () => '/books/entries/me',
+      providesTags: ['Book'],
+    }),
+
+    /**
+     * Добавление книги в общий каталог.
+     */
+    createBook: build.mutation<Book, CreateBookDto>({
+      query: (body) => ({ url: '/books', method: 'POST', body }),
+      invalidatesTags: ['Book'],
+    }),
+
+    /**
+     * Обновление книги по ID.
+     */
+    updateBook: build.mutation<Book, { id: string; dto: UpdateBookDto }>({
+      query: ({ id, dto }) => ({ url: `/books/${id}`, method: 'PATCH', body: dto }),
+      invalidatesTags: ['Book'],
+    }),
+
+    /**
+     * Удаление книги по ID.
+     */
+    deleteBook: build.mutation<void, string>({
+      query: (id) => ({ url: `/books/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Book'],
+    }),
+
+    /**
+     * Добавление книги в список пользователя.
+     */
+    createEntry: build.mutation<BookEntry, CreateBookEntryDto>({
+      query: (body) => ({ url: '/books/entries', method: 'POST', body }),
+      invalidatesTags: ['Book'],
+    }),
+
+    /**
+     * Обновление записи пользователя по ID (статус, оценка, прогресс и т.д.).
+     */
+    updateEntry: build.mutation<BookEntry, { id: string; dto: UpdateBookEntryDto }>({
+      query: ({ id, dto }) => ({ url: `/books/entries/${id}`, method: 'PATCH', body: dto }),
+      invalidatesTags: ['Book'],
+    }),
+
+    /**
+     * Удаление записи пользователя по ID.
+     */
+    deleteEntry: build.mutation<void, string>({
+      query: (id) => ({ url: `/books/entries/${id}`, method: 'DELETE' }),
+      invalidatesTags: ['Book'],
+    }),
+  }),
+})
+
+export const {
+  useGetBooksQuery,
+  useGetMyEntriesQuery,
+  useCreateBookMutation,
+  useUpdateBookMutation,
+  useDeleteBookMutation,
+  useCreateEntryMutation,
+  useUpdateEntryMutation,
+  useDeleteEntryMutation,
+} = booksApi

--- a/apps/web/src/features/book/index.ts
+++ b/apps/web/src/features/book/index.ts
@@ -1,0 +1,16 @@
+export {
+  useGetBooksQuery,
+  useGetMyEntriesQuery,
+  useCreateBookMutation,
+  useUpdateBookMutation,
+  useDeleteBookMutation,
+  useCreateEntryMutation,
+  useUpdateEntryMutation,
+  useDeleteEntryMutation,
+} from './api/booksApi'
+export type {
+  CreateBookDto,
+  UpdateBookDto,
+  CreateBookEntryDto,
+  UpdateBookEntryDto,
+} from './api/booksApi'


### PR DESCRIPTION
## Что сделано
- `features/book/api/booksApi.ts` — `baseApi.injectEndpoints` с 8 эндпоинтами: `getBooks`, `getMyEntries`, `createBook`, `updateBook`, `deleteBook`, `createEntry`, `updateEntry`, `deleteEntry`
- Тег `Book` для providesTags/invalidatesTags — мутации автоматически инвалидируют кэш запросов
- `features/book/index.ts` — экспорт хуков и DTO-типов

## Не входит
Подключение `LibraryPage` к этим данным — отдельная задача.

## Проверка
- `npx tsc --noEmit` — чисто
- `npx vitest run` — 4 файла, 12 тестов, все проходят