### PR TITLE
feat(web): подключить library page к реальным данным (#116)

### DIFF
--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -103,3 +103,33 @@ $bp-sm: 600px;
     padding: 10px 20px 24px;
   }
 }
+
+// ─── Пустое состояние / ошибка ────────────────────────────────────────────────
+
+.library__empty {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 60px 20px;
+  color: var(--color-text-2, #666);
+  text-align: center;
+}
+
+.library__empty-icon {
+  opacity: 0.3;
+}
+
+.library__empty-text {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.library__empty-sub {
+  margin: 0;
+  font-size: 13px;
+  opacity: 0.7;
+}

--- a/apps/web/src/pages/library/LibraryPage.test.tsx
+++ b/apps/web/src/pages/library/LibraryPage.test.tsx
@@ -1,16 +1,36 @@
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { Provider } from 'react-redux'
 import { MemoryRouter } from 'react-router'
+import { configureStore } from '@reduxjs/toolkit'
+import { authReducer } from '@/features/auth'
+import { baseApi } from '@/shared/api/baseApi'
 import { LibraryPage } from './LibraryPage'
+
+const makeStore = () =>
+  configureStore({
+    reducer: {
+      auth: authReducer,
+      [baseApi.reducerPath]: baseApi.reducer,
+    },
+    middleware: (m) => m().concat(baseApi.middleware),
+  })
 
 // Smoke-тест: компонент рендерится без ошибок и показывает заголовок.
 describe('LibraryPage', () => {
-  it('renders heading', () => {
+  it('renders heading', async () => {
     render(
-      <MemoryRouter>
-        <LibraryPage />
-      </MemoryRouter>,
+      <Provider store={makeStore()}>
+        <MemoryRouter>
+          <LibraryPage />
+        </MemoryRouter>
+      </Provider>,
     )
-    expect(screen.getByText('Моя библиотека')).toBeInTheDocument()
+
+    // useGetMyEntriesQuery резолвится асинхронно даже для гостя без токена,
+    // поэтому ждём пока компонент выйдет из состояния загрузки.
+    await waitFor(() => {
+      expect(screen.getByText('Моя библиотека')).toBeInTheDocument()
+    })
   })
 })

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -1,88 +1,19 @@
 import { useState } from 'react'
-import { LayoutGrid, Image } from 'lucide-react'
-import { BookCard, BookCoverCard, type BookEntry } from '@/entities/book'
+import { BookOpen, Image, LayoutGrid } from 'lucide-react'
+import { BookCard, BookCoverCard } from '@/entities/book'
+import { useGetMyEntriesQuery } from '@/features/book'
 import styles from './LibraryPage.module.scss'
 
 /** Стиль отображения карточек книги. */
 type CardStyle = 'compact' | 'cover'
 
-const MOCK_ENTRIES: BookEntry[] = [
-  {
-    id: '1',
-    userId: '1',
-    bookId: '1',
-    status: 'READING',
-    rating: null,
-    progress: 120,
-    startDate: '2026-01-01',
-    finishDate: null,
-    notes: null,
-    createdAt: '',
-    updatedAt: '',
-    book: {
-      id: '1',
-      title: 'Мастер и Маргарита',
-      author: 'Михаил Булгаков',
-      coverUrl: null,
-      description: null,
-      pageCount: 480,
-      genres: ['Роман'],
-      createdAt: '',
-      updatedAt: '',
-    },
-  },
-  {
-    id: '2',
-    userId: '1',
-    bookId: '2',
-    status: 'DONE',
-    rating: 9,
-    progress: null,
-    startDate: '2025-12-01',
-    finishDate: '2026-01-15',
-    notes: null,
-    createdAt: '',
-    updatedAt: '',
-    book: {
-      id: '2',
-      title: 'Преступление и наказание',
-      author: 'Фёдор Достоевский',
-      coverUrl: null,
-      description: null,
-      pageCount: 592,
-      genres: ['Роман'],
-      createdAt: '',
-      updatedAt: '',
-    },
-  },
-  {
-    id: '3',
-    userId: '1',
-    bookId: '3',
-    status: 'WANT',
-    rating: null,
-    progress: null,
-    startDate: null,
-    finishDate: null,
-    notes: null,
-    createdAt: '',
-    updatedAt: '',
-    book: {
-      id: '3',
-      title: 'Война и мир',
-      author: 'Лев Толстой',
-      coverUrl: null,
-      description: null,
-      pageCount: 1225,
-      genres: ['Роман'],
-      createdAt: '',
-      updatedAt: '',
-    },
-  },
-]
-
 export const LibraryPage = () => {
   const [cardStyle, setCardStyle] = useState<CardStyle>('compact')
+  const { data, isLoading, isError } = useGetMyEntriesQuery()
+  const entries = data ?? []
+  const showEmpty = isError || entries.length === 0
+
+  if (isLoading) return null
 
   return (
     <div className={styles.library}>
@@ -91,7 +22,7 @@ export const LibraryPage = () => {
       </div>
 
       <div className={styles['library__label-row']}>
-        <span className={styles['library__label']}>{MOCK_ENTRIES.length} книг</span>
+        <span className={styles['library__label']}>{entries.length} книг</span>
 
         <div className={styles['library__style-toggle']}>
           <button
@@ -111,15 +42,29 @@ export const LibraryPage = () => {
         </div>
       </div>
 
-      <div className={styles['library__grid']}>
-        {MOCK_ENTRIES.map((entry) =>
-          cardStyle === 'compact' ? (
-            <BookCard key={entry.id} entry={entry} />
-          ) : (
-            <BookCoverCard key={entry.id} entry={entry} />
-          ),
-        )}
-      </div>
+      {showEmpty ? (
+        <div className={styles['library__empty']}>
+          <div className={styles['library__empty-icon']}>
+            <BookOpen size={48} />
+          </div>
+          <p className={styles['library__empty-text']}>
+            {isError ? 'Не удалось загрузить библиотеку' : 'Список книг пуст'}
+          </p>
+          <p className={styles['library__empty-sub']}>
+            {isError ? 'Попробуй обновить страницу' : 'Добавь первую книгу в свою библиотеку'}
+          </p>
+        </div>
+      ) : (
+        <div className={styles['library__grid']}>
+          {entries.map((entry) =>
+            cardStyle === 'compact' ? (
+              <BookCard key={entry.id} entry={entry} />
+            ) : (
+              <BookCoverCard key={entry.id} entry={entry} />
+            ),
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -363,6 +363,9 @@ $bp-md: 900px;
 // ─── Сетка (пустое состояние) ─────────────────────────────────────────────────
 
 .grid-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
   padding: 20px 40px 60px;
 
   @media (max-width: $bp-sm) {
@@ -371,6 +374,7 @@ $bp-md: 900px;
 }
 
 .empty-state {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Что сделано
- `LibraryPage` — заменил моковые данные на `useGetMyEntriesQuery` из `booksApi`
- Состояние загрузки, состояние ошибки, пустое состояние (список книг пуст)
- Пустое состояние теперь центрируется по вертикали — поправил заодно и в `ProfilePage` (тот же паттерн `grid-section`/`empty-state`)
- Тест `LibraryPage.test.tsx` обёрнут в Redux `Provider`, так как компонент теперь использует RTK Query

## Не входит
Форма добавления книги — отдельная задача.

## Проверка
- `npx tsc --noEmit` — чисто
- `npx vitest run` — 4 файла, 12 тестов, все проходят