### PR TITLE
feat(web): пустое состояние библиотеки и форма добавления книги (#118)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,6 +23,7 @@
     "lucide-react": "^1.14.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.79.0",
     "react-redux": "^9.2.0",
     "react-router": "^7.14.2"
   },

--- a/apps/web/src/features/book/index.ts
+++ b/apps/web/src/features/book/index.ts
@@ -14,3 +14,4 @@ export type {
   CreateBookEntryDto,
   UpdateBookEntryDto,
 } from './api/booksApi'
+export { AddBookDialog } from './ui/AddBookDialog/AddBookDialog'

--- a/apps/web/src/features/book/ui/AddBookDialog/AddBookDialog.tsx
+++ b/apps/web/src/features/book/ui/AddBookDialog/AddBookDialog.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react'
+import { useForm, Controller } from 'react-hook-form'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  TextField,
+  MenuItem,
+  Button,
+  Stack,
+  Typography,
+} from '@mui/material'
+import type { BookStatus } from '@/entities/book'
+import { useCreateBookMutation, useCreateEntryMutation } from '../../api/booksApi'
+
+/** Варианты статуса книги для выбора в форме. */
+const STATUS_OPTIONS: { value: BookStatus; label: string }[] = [
+  { value: 'WANT', label: 'Хочу прочитать' },
+  { value: 'READING', label: 'Читаю' },
+  { value: 'DONE', label: 'Прочитал' },
+  { value: 'DROPPED', label: 'Брошено' },
+]
+
+/**
+ * Значения полей формы добавления книги.
+ */
+interface AddBookFormValues {
+  /** Название книги. */
+  title: string
+  /** Автор книги. */
+  author: string
+  /** URL обложки. */
+  coverUrl: string
+  /** Количество страниц (строка из инпута, переводится в число при отправке). */
+  pageCount: string
+  /** Статус, с которым книга добавляется в список. */
+  status: BookStatus
+}
+
+/** Начальные значения формы добавления книги. */
+const DEFAULT_VALUES: AddBookFormValues = {
+  title: '',
+  author: '',
+  coverUrl: '',
+  pageCount: '',
+  status: 'WANT',
+}
+
+/** Значение автора, если поле оставлено пустым. */
+const UNKNOWN_AUTHOR = 'Автор неизвестен'
+
+/**
+ * Пропсы AddBookDialog.
+ */
+interface AddBookDialogProps {
+  /** Открыта ли модалка. */
+  open: boolean
+  /** Закрытие модалки. */
+  onClose: () => void
+}
+
+/**
+ * Модалка добавления книги — создаёт книгу в каталоге и сразу запись пользователя.
+ */
+export const AddBookDialog = ({ open, onClose }: AddBookDialogProps) => {
+  const [error, setError] = useState<string | null>(null)
+  const [createBook] = useCreateBookMutation()
+  const [createEntry] = useCreateEntryMutation()
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<AddBookFormValues>({
+    defaultValues: DEFAULT_VALUES,
+    mode: 'onChange',
+  })
+
+  /**
+   * Функция закрытия модалки с очисткой формы.
+   */
+  const handleClose = () => {
+    if (isSubmitting) return
+    reset(DEFAULT_VALUES)
+    setError(null)
+    onClose()
+  }
+
+  /**
+   * Функция отправки формы — создаёт книгу и сразу запись пользователя.
+   */
+  const onSubmit = async (values: AddBookFormValues) => {
+    setError(null)
+    try {
+      const book = await createBook({
+        title: values.title.trim(),
+        author: values.author.trim() || UNKNOWN_AUTHOR,
+        ...(values.coverUrl.trim() && { coverUrl: values.coverUrl.trim() }),
+        ...(values.pageCount && { pageCount: Number(values.pageCount) }),
+      }).unwrap()
+
+      await createEntry({ bookId: book.id, status: values.status }).unwrap()
+
+      reset(DEFAULT_VALUES)
+      onClose()
+    } catch {
+      setError('Не удалось добавить книгу. Попробуй ещё раз.')
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <DialogTitle>Добавить книгу</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} sx={{ mt: 1 }}>
+            <TextField
+              label="Название"
+              required
+              fullWidth
+              autoFocus
+              error={!!errors.title}
+              helperText={errors.title ? 'Обязательное поле' : ''}
+              {...register('title', { required: true })}
+            />
+            <TextField label="Автор" fullWidth {...register('author')} />
+            <TextField label="Обложка (URL)" fullWidth {...register('coverUrl')} />
+
+            <Stack direction="row" spacing={2}>
+              <TextField
+                label="Количество страниц"
+                type="number"
+                sx={{ flex: 1 }}
+                {...register('pageCount')}
+              />
+              <Controller
+                name="status"
+                control={control}
+                render={({ field }) => (
+                  <TextField select label="Статус" sx={{ flex: 1 }} {...field}>
+                    {STATUS_OPTIONS.map((option) => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                )}
+              />
+            </Stack>
+
+            {error && <Typography color="error">{error}</Typography>}
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} disabled={isSubmitting}>
+            Отмена
+          </Button>
+          <Button type="submit" variant="contained" disabled={!isValid || isSubmitting}>
+            Добавить
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}

--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -17,10 +17,37 @@ $bp-sm: 600px;
 // ─── Шапка ────────────────────────────────────────────────────────────────────
 
 .library__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
   padding: 28px 36px 12px;
 
   @media (max-width: $bp-sm) {
     padding: 20px 20px 10px;
+  }
+}
+
+.library__add-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 18px;
+  border: none;
+  border-radius: 10px;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: filter 0.15s, transform 0.15s;
+
+  &:hover {
+    filter: brightness(1.08);
+    transform: translateY(-1px);
   }
 }
 
@@ -131,5 +158,141 @@ $bp-sm: 600px;
 .library__empty-sub {
   margin: 0;
   font-size: 13px;
+  opacity: 0.7;
+}
+
+// ─── Пустая библиотека (нет книг) ─────────────────────────────────────────────
+
+.library__empty-lib {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 40px 24px;
+  animation: rise 0.5s ease both;
+}
+
+@keyframes floaty {
+  0%, 100% { transform: translateY(0) rotate(var(--rot, 0deg)); }
+  50%      { transform: translateY(-7px) rotate(var(--rot, 0deg)); }
+}
+
+.library__empty-shelf {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 14px;
+  height: 140px;
+  margin-bottom: 28px;
+}
+
+.library__ghost {
+  width: 70px;
+  aspect-ratio: 2 / 3;
+  border-radius: 9px;
+  border: 1.5px dashed var(--color-divider, #d5e4d8);
+  background: linear-gradient(160deg, var(--color-paper, #fafcf9), var(--color-paper-2, #ecf1ea));
+  position: relative;
+  opacity: 0.9;
+  animation: floaty 4.5s ease-in-out infinite;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 10px;
+    bottom: 10px;
+    width: 2px;
+    border-radius: 2px;
+    background: var(--color-divider, #d5e4d8);
+  }
+
+  &:first-child { --rot: -6deg; }
+  &:last-child { --rot: 6deg; }
+
+  &--tall {
+    height: 122px;
+    animation-delay: 0.5s;
+  }
+
+  &--accent {
+    border-style: solid;
+    border-color: var(--color-primary, #4e7b6a);
+    background: linear-gradient(160deg, var(--color-chip-bg, #dff0e5), transparent);
+    animation-delay: 0.25s;
+    z-index: 1;
+
+    &::after {
+      content: '';
+      position: absolute;
+      top: 9px;
+      right: 9px;
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      border: 2px dashed var(--color-primary, #4e7b6a);
+    }
+  }
+}
+
+.library__empty-title {
+  margin: 0 0 10px;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--color-text, inherit);
+}
+
+.library__empty-desc {
+  margin: 0 0 26px;
+  max-width: 36ch;
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--color-text-2, #666);
+}
+
+.library__empty-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.library__cta-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 11px;
+  background: var(--color-primary, #4e7b6a);
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: filter 0.15s, transform 0.15s;
+
+  &:hover {
+    filter: brightness(1.08);
+    transform: translateY(-1px);
+  }
+}
+
+.library__cta-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border: 1px solid var(--color-divider, #d5e4d8);
+  border-radius: 11px;
+  background: var(--color-paper, white);
+  color: var(--color-text-2, #666);
+  font-size: 14px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: not-allowed;
   opacity: 0.7;
 }

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -1,17 +1,21 @@
 import { useState } from 'react'
-import { BookOpen, Image, LayoutGrid } from 'lucide-react'
+import { BookOpen, Image, LayoutGrid, Plus, Upload } from 'lucide-react'
 import { BookCard, BookCoverCard } from '@/entities/book'
-import { useGetMyEntriesQuery } from '@/features/book'
+import { AddBookDialog, useGetMyEntriesQuery } from '@/features/book'
 import styles from './LibraryPage.module.scss'
 
 /** Стиль отображения карточек книги. */
 type CardStyle = 'compact' | 'cover'
 
+/**
+ * Страница библиотеки пользователя.
+ */
 export const LibraryPage = () => {
   const [cardStyle, setCardStyle] = useState<CardStyle>('compact')
+  const [addOpen, setAddOpen] = useState(false)
   const { data, isLoading, isError } = useGetMyEntriesQuery()
   const entries = data ?? []
-  const showEmpty = isError || entries.length === 0
+  const isEmpty = !isError && entries.length === 0
 
   if (isLoading) return null
 
@@ -19,40 +23,66 @@ export const LibraryPage = () => {
     <div className={styles.library}>
       <div className={styles['library__header']}>
         <h1 className={styles['library__title']}>Моя библиотека</h1>
+        <button className={styles['library__add-btn']} onClick={() => setAddOpen(true)}>
+          <Plus size={16} />
+          Добавить книгу
+        </button>
       </div>
 
-      <div className={styles['library__label-row']}>
-        <span className={styles['library__label']}>{entries.length} книг</span>
+      {!isError && (
+        <div className={styles['library__label-row']}>
+          <span className={styles['library__label']}>{entries.length} книг</span>
 
-        <div className={styles['library__style-toggle']}>
-          <button
-            className={`${styles['library__style-btn']} ${cardStyle === 'compact' ? styles['library__style-btn--active'] : ''}`}
-            onClick={() => setCardStyle('compact')}
-            title="Компактный вид"
-          >
-            <LayoutGrid size={16} />
-          </button>
-          <button
-            className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
-            onClick={() => setCardStyle('cover')}
-            title="Вид обложками"
-          >
-            <Image size={16} />
-          </button>
+          <div className={styles['library__style-toggle']}>
+            <button
+              className={`${styles['library__style-btn']} ${cardStyle === 'compact' ? styles['library__style-btn--active'] : ''}`}
+              onClick={() => setCardStyle('compact')}
+              title="Компактный вид"
+            >
+              <LayoutGrid size={16} />
+            </button>
+            <button
+              className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
+              onClick={() => setCardStyle('cover')}
+              title="Вид обложками"
+            >
+              <Image size={16} />
+            </button>
+          </div>
         </div>
-      </div>
+      )}
 
-      {showEmpty ? (
+      {isError ? (
         <div className={styles['library__empty']}>
           <div className={styles['library__empty-icon']}>
             <BookOpen size={48} />
           </div>
-          <p className={styles['library__empty-text']}>
-            {isError ? 'Не удалось загрузить библиотеку' : 'Список книг пуст'}
+          <p className={styles['library__empty-text']}>Не удалось загрузить библиотеку</p>
+          <p className={styles['library__empty-sub']}>Попробуй обновить страницу</p>
+        </div>
+      ) : isEmpty ? (
+        <div className={styles['library__empty-lib']}>
+          <div className={styles['library__empty-shelf']}>
+            <div className={styles['library__ghost']} />
+            <div className={`${styles['library__ghost']} ${styles['library__ghost--tall']}`} />
+            <div className={`${styles['library__ghost']} ${styles['library__ghost--accent']}`} />
+            <div className={`${styles['library__ghost']} ${styles['library__ghost--tall']}`} />
+            <div className={styles['library__ghost']} />
+          </div>
+          <h2 className={styles['library__empty-title']}>Здесь пока пусто</h2>
+          <p className={styles['library__empty-desc']}>
+            Добавь первую книгу — и она появится на твоей полке.
           </p>
-          <p className={styles['library__empty-sub']}>
-            {isError ? 'Попробуй обновить страницу' : 'Добавь первую книгу в свою библиотеку'}
-          </p>
+          <div className={styles['library__empty-actions']}>
+            <button className={styles['library__cta-primary']} onClick={() => setAddOpen(true)}>
+              <Plus size={17} />
+              Добавить книгу
+            </button>
+            <button className={styles['library__cta-ghost']} disabled title="Скоро">
+              <Upload size={16} />
+              Импортировать список
+            </button>
+          </div>
         </div>
       ) : (
         <div className={styles['library__grid']}>
@@ -65,6 +95,8 @@ export const LibraryPage = () => {
           )}
         </div>
       )}
+
+      <AddBookDialog open={addOpen} onClose={() => setAddOpen(false)} />
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,7 @@
         "lucide-react": "^1.14.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.79.0",
         "react-redux": "^9.2.0",
         "react-router": "^7.14.2"
       },
@@ -14885,6 +14886,22 @@
       },
       "peerDependencies": {
         "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.79.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.79.0.tgz",
+      "integrity": "sha512-mhYp/MTmXvzYX6AJcJVko0rktoIhhmRnEouObj4wF5i/tCttgJvnp1+9wRkpITZjDTqpo4IOSJqu0dBlPlV/Lw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
## Что сделано
- Пустое состояние библиотеки по референсу: «полка» из 5 пунктирных обложек с плавающей анимацией, заголовок «Здесь пока пусто», кнопка «Добавить книгу» (primary) и неактивная «Импортировать список» (как `import-strip` на главной)
- Кнопка «Добавить книгу» в шапке страницы — видна всегда
- `AddBookDialog` на `react-hook-form` — название (обязательно), автор/обложка/страницы (опционально), статус. Если автор не указан — отправляется «Автор неизвестен» (бэкенд требует непустую строку)
- Создание: `createBook` → `createEntry` с полученным `bookId`

## Известная проблема (выносим в отдельную задачу)
401 при попытке добавить книгу от имени гостя/с истёкшей сессией — нужен redirect-after-login механизм и блокировка действия для гостя до открытия формы.

## Проверка
- `npx tsc --noEmit` — чисто
- `npx vitest run` — 4 файла, 12 тестов, все проходят