### PR TITLE
feat(web): redirect после логина и блокировка добавления книги для гостя

### DIFF
--- a/apps/web/src/app/providers/ThemeProvider.tsx
+++ b/apps/web/src/app/providers/ThemeProvider.tsx
@@ -22,6 +22,8 @@ export const ThemeProvider = ({ children }: Props) => {
   const { lightVariant, darkVariant, isDark, themeMode } = useAppSelector((s) => s.theme)
   const activeVariant = isDark ? darkVariant : lightVariant
   const theme = useMemo(() => buildTheme(activeVariant), [activeVariant])
+  // Тема для «ghost»-карточек пустой библиотеки — всегда тёмная, независимо от isDark
+  const ghostTheme = useMemo(() => buildTheme(darkVariant), [darkVariant])
 
   // Следим за системной темой когда выбран режим «Как на устройстве»
   useEffect(() => {
@@ -75,7 +77,16 @@ export const ThemeProvider = ({ children }: Props) => {
     root.style.setProperty('--login-hero-bg', lightColors.sidebarBg)
     root.style.setProperty('--login-hero-text', lightColors.sidebarText)
     root.style.setProperty('--login-hero-muted', lightColors.sidebarMuted)
-  }, [theme, activeVariant, isDark, lightVariant])
+
+    // Токены для ghost-карточек пустой библиотеки — все завязаны на primary тёмной темы
+    // (тот же цвет, что и у акцентной карточки), просто с разной степенью прозрачности.
+    const ghostPalette = ghostTheme.palette
+    root.style.setProperty('--ghost-primary', ghostPalette.primary.main)
+    root.style.setProperty('--ghost-chip-bg', ghostPalette.primary.light + '33') // ~20%
+    root.style.setProperty('--ghost-border', ghostPalette.primary.main + '4D') // ~30%
+    root.style.setProperty('--ghost-bg-1', ghostPalette.primary.light + '26') // ~15%
+    root.style.setProperty('--ghost-bg-2', ghostPalette.primary.light + '0D') // ~5%
+  }, [theme, activeVariant, isDark, lightVariant, ghostTheme])
 
   return (
     <StyledEngineProvider injectFirst>

--- a/apps/web/src/app/router.tsx
+++ b/apps/web/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, Navigate, Outlet } from 'react-router'
+import { createBrowserRouter, Navigate, Outlet, useLocation } from 'react-router'
 import { Box, CircularProgress } from '@mui/material'
 import { AuthCallbackPage } from '@/pages/auth-callback'
 import { HomePage } from '@/pages/home'
@@ -6,6 +6,7 @@ import { LibraryPage } from '@/pages/library'
 import { LoginPage } from '@/pages/login'
 import { ProfilePage } from '@/pages/profile'
 import { SettingsPage } from '@/pages/settings'
+import { saveRedirectPath } from '@/shared/lib/redirectPath'
 import { useAppSelector } from '@/shared/lib/store'
 import { AppLayout } from '@/widgets/layout'
 
@@ -14,6 +15,7 @@ import { AppLayout } from '@/widgets/layout'
  */
 function RequireAuth() {
   const { accessToken, isGuest, isInitialized } = useAppSelector((s) => s.auth)
+  const location = useLocation()
 
   // Ждём завершения проверки сессии в AuthProvider перед редиректом
   if (!isInitialized) {
@@ -27,6 +29,7 @@ function RequireAuth() {
   }
 
   if (!accessToken && !isGuest) {
+    saveRedirectPath(location.pathname)
     return <Navigate to="/login" replace />
   }
 

--- a/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useSearchParams } from 'react-router'
 import { Box, CircularProgress } from '@mui/material'
 import type { User } from '@/entities/user'
 import { setCredentials, setUser } from '@/features/auth'
+import { consumeRedirectPath } from '@/shared/lib/redirectPath'
 import { useAppDispatch } from '@/shared/lib/store'
 
 /**
@@ -36,7 +37,7 @@ export function AuthCallbackPage() {
           dispatch(setUser(user))
         }
       } finally {
-        void navigate('/', { replace: true })
+        void navigate(consumeRedirectPath() ?? '/', { replace: true })
       }
     }
 

--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -192,8 +192,8 @@ $bp-sm: 600px;
   width: 70px;
   aspect-ratio: 2 / 3;
   border-radius: 9px;
-  border: 1.5px dashed var(--color-divider, #d5e4d8);
-  background: linear-gradient(160deg, var(--color-paper, #fafcf9), var(--color-paper-2, #ecf1ea));
+  border: 1.5px dashed var(--ghost-border, #6fa68c4d);
+  background: linear-gradient(160deg, var(--ghost-bg-1, #6fa68c26), var(--ghost-bg-2, #6fa68c0d));
   position: relative;
   opacity: 0.9;
   animation: floaty 4.5s ease-in-out infinite;
@@ -206,7 +206,7 @@ $bp-sm: 600px;
     bottom: 10px;
     width: 2px;
     border-radius: 2px;
-    background: var(--color-divider, #d5e4d8);
+    background: var(--ghost-border, #6fa68c4d);
   }
 
   &:first-child { --rot: -6deg; }
@@ -219,8 +219,8 @@ $bp-sm: 600px;
 
   &--accent {
     border-style: solid;
-    border-color: var(--color-primary, #4e7b6a);
-    background: linear-gradient(160deg, var(--color-chip-bg, #dff0e5), transparent);
+    border-color: var(--ghost-primary, #6fa68c);
+    background: linear-gradient(160deg, var(--ghost-chip-bg, #6fa68c33), transparent);
     animation-delay: 0.25s;
     z-index: 1;
 
@@ -232,7 +232,7 @@ $bp-sm: 600px;
       width: 24px;
       height: 24px;
       border-radius: 50%;
-      border: 2px dashed var(--color-primary, #4e7b6a);
+      border: 2px dashed var(--ghost-primary, #6fa68c);
     }
   }
 }

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -1,7 +1,18 @@
 import { useState } from 'react'
 import { BookOpen, Image, LayoutGrid, Plus, Upload } from 'lucide-react'
+import { useNavigate } from 'react-router'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+} from '@mui/material'
 import { BookCard, BookCoverCard } from '@/entities/book'
 import { AddBookDialog, useGetMyEntriesQuery } from '@/features/book'
+import { saveRedirectPath } from '@/shared/lib/redirectPath'
+import { useAppSelector } from '@/shared/lib/store'
 import styles from './LibraryPage.module.scss'
 
 /** Стиль отображения карточек книги. */
@@ -13,9 +24,27 @@ type CardStyle = 'compact' | 'cover'
 export const LibraryPage = () => {
   const [cardStyle, setCardStyle] = useState<CardStyle>('compact')
   const [addOpen, setAddOpen] = useState(false)
+  const [guestPromptOpen, setGuestPromptOpen] = useState(false)
+  const isGuest = useAppSelector((s) => s.auth.isGuest)
+  const navigate = useNavigate()
   const { data, isLoading, isError } = useGetMyEntriesQuery()
   const entries = data ?? []
   const isEmpty = !isError && entries.length === 0
+
+  /** Открывает форму добавления книги, либо для гостя — предлагает войти. */
+  const handleAddClick = () => {
+    if (isGuest) {
+      setGuestPromptOpen(true)
+      return
+    }
+    setAddOpen(true)
+  }
+
+  /** Сохраняет текущий путь и ведёт на страницу входа. */
+  const handleGoToLogin = () => {
+    saveRedirectPath('/library')
+    void navigate('/login')
+  }
 
   if (isLoading) return null
 
@@ -23,7 +52,7 @@ export const LibraryPage = () => {
     <div className={styles.library}>
       <div className={styles['library__header']}>
         <h1 className={styles['library__title']}>Моя библиотека</h1>
-        <button className={styles['library__add-btn']} onClick={() => setAddOpen(true)}>
+        <button className={styles['library__add-btn']} onClick={handleAddClick}>
           <Plus size={16} />
           Добавить книгу
         </button>
@@ -74,7 +103,7 @@ export const LibraryPage = () => {
             Добавь первую книгу — и она появится на твоей полке.
           </p>
           <div className={styles['library__empty-actions']}>
-            <button className={styles['library__cta-primary']} onClick={() => setAddOpen(true)}>
+            <button className={styles['library__cta-primary']} onClick={handleAddClick}>
               <Plus size={17} />
               Добавить книгу
             </button>
@@ -97,6 +126,27 @@ export const LibraryPage = () => {
       )}
 
       <AddBookDialog open={addOpen} onClose={() => setAddOpen(false)} />
+
+      <Dialog open={guestPromptOpen} onClose={() => setGuestPromptOpen(false)}>
+        <DialogTitle sx={{ pt: 3, px: 3 }}>Необходимо войти</DialogTitle>
+        <DialogContent sx={{ px: 3 }}>
+          <DialogContentText>
+            Добавлять книги может только зарегистрированный пользователь.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3, gap: 1 }}>
+          <Button
+            variant="outlined"
+            sx={{ minWidth: 100 }}
+            onClick={() => setGuestPromptOpen(false)}
+          >
+            Отмена
+          </Button>
+          <Button variant="contained" sx={{ minWidth: 100 }} onClick={handleGoToLogin}>
+            Войти
+          </Button>
+        </DialogActions>
+      </Dialog>
     </div>
   )
 }

--- a/apps/web/src/shared/lib/redirectPath.ts
+++ b/apps/web/src/shared/lib/redirectPath.ts
@@ -1,0 +1,19 @@
+const REDIRECT_PATH_KEY = 'redirectPath'
+
+/**
+ * Сохраняет путь, куда нужно вернуть пользователя после входа.
+ * Используется localStorage, а не location.state — между /login и /auth/callback
+ * происходит полный браузерный redirect через Google, а не SPA-навигация.
+ */
+export function saveRedirectPath(path: string) {
+  localStorage.setItem(REDIRECT_PATH_KEY, path)
+}
+
+/**
+ * Возвращает сохранённый путь и удаляет его из хранилища (одноразовое использование).
+ */
+export function consumeRedirectPath(): string | null {
+  const path = localStorage.getItem(REDIRECT_PATH_KEY)
+  if (path) localStorage.removeItem(REDIRECT_PATH_KEY)
+  return path
+}


### PR DESCRIPTION
Closes #120

## Что сделано
- Хелпер `saveRedirectPath`/`consumeRedirectPath` (localStorage) — общий механизм для всего приложения
- `RequireAuth` сохраняет текущий путь перед редиректом на `/login`
- `AuthCallbackPage` после входа возвращает пользователя на сохранённый путь вместо хардкода `/`
- На `LibraryPage` для гостя кнопки «Добавить книгу» открывают диалог «Необходимо войти» вместо формы добавления
- Ghost-карточки пустой библиотеки адаптированы под все темы (привязаны к primary-цвету темы)

## Тестирование
- [x] `tsc --noEmit` — без ошибок
- [x] `vitest run` — 12/12 тестов