### PR TITLE
feat(web): редактирование статуса и оценки книги

### DIFF
--- a/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
@@ -25,16 +25,19 @@ const STATUS_COLOR: Record<BookStatus, 'default' | 'info' | 'success' | 'error'>
 interface BookCardProps {
   /** Запись пользователя с данными книги. */
   entry: BookEntry
+  /** Клик по карточке — открывает редактирование записи. */
+  onClick?: () => void
 }
 
 /**
  * Карточка книги для отображения в библиотеке.
  */
-export const BookCard = ({ entry }: BookCardProps) => {
+export const BookCard = ({ entry, onClick }: BookCardProps) => {
   const { book, status, rating } = entry
 
   return (
     <Card
+      onClick={onClick}
       sx={(theme) => ({
         width: 160,
         bgcolor: 'background.paper',

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
@@ -8,12 +8,25 @@
 
 // ─── Обложка ──────────────────────────────────────────────────────────────────
 
+// Регистрируем угол как анимируемое CSS-свойство — это позволяет крутить
+// именно угол conic-gradient (саму «комету»), а не сам элемент. Если вращать
+// элемент через transform, его углы (он прямоугольный) выезжают за пределы
+// круглого/скруглённого контура во время поворота — заметно «квадратное» пятно.
+@property --gold-angle {
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
+}
+
 .cover-card__cover {
   position: relative;
   aspect-ratio: 2 / 3;
   border-radius: 10px;
   overflow: hidden;
-  background: var(--color-primary, #4e7b6a);
+  // Градиент от основного цвета темы к его тёмному оттенку — оба токена
+  // приходят из текущей темы, поэтому обложка остаётся глубже и не «кричащей»
+  // на любой из 12 палитр, а не только при хардкоде конкретного цвета.
+  background: linear-gradient(150deg, var(--color-primary, #4e7b6a), var(--color-primary-dark, #3a5c4f));
   box-shadow: 0 10px 24px -12px rgba(0, 0, 0, 0.5);
   display: flex;
   flex-direction: column;
@@ -33,12 +46,16 @@
     border-radius: 2px;
   }
 
-  // Лёгкая текстура бумаги
+  // Лёгкая текстура бумаги сверху-справа + затемнение в нижнем правом углу.
+  // Затемнение — полупрозрачный чёрный поверх градиента, а не отдельный цвет,
+  // поэтому соотношение тонов сохраняется на любой теме.
   &::after {
     content: '';
     position: absolute;
     inset: 0;
-    background: radial-gradient(120% 80% at 100% 0%, rgba(255, 255, 255, 0.12), transparent 55%);
+    background:
+      radial-gradient(120% 80% at 100% 0%, rgba(255, 255, 255, 0.12), transparent 55%),
+      linear-gradient(150deg, transparent 45%, rgba(0, 0, 0, 0.35) 100%);
     pointer-events: none;
   }
 
@@ -46,6 +63,40 @@
     transform: translateY(-4px);
     box-shadow: 0 18px 32px -14px rgba(0, 0, 0, 0.55);
   }
+}
+
+// Идеальная оценка 10/10 — золотая «комета», бегущая по тонкому ободку вдоль
+// края обложки, как индикатор загрузки. padding + mask-composite:exclude
+// «вырезает» из закрашенного квадрата только полоску по периметру (между
+// border-box и content-box), остальное прозрачно — сама обложка видна сквозь.
+.cover-card__gold-ring {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  border-radius: inherit;
+  pointer-events: none;
+  padding: 4px;
+  background:
+    conic-gradient(
+      from var(--gold-angle),
+      rgba(255, 225, 150, 0) 0deg,
+      rgba(255, 225, 150, 0) 200deg,
+      rgba(255, 232, 170, 0.55) 270deg,
+      #ffe9a8 320deg,
+      #ffd24a 345deg,
+      rgba(255, 225, 150, 0) 360deg
+    ),
+    // тонкий золотой ободок по всему периметру, чтобы «комета» не гасла на пустом участке
+    conic-gradient(rgba(212, 175, 55, 0.22) 0deg 360deg);
+  -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  animation: cover-card-gold-spin 2.4s linear infinite;
+  filter: drop-shadow(0 0 4px rgba(255, 210, 90, 0.35));
+}
+
+@keyframes cover-card-gold-spin {
+  to { --gold-angle: 360deg; }
 }
 
 .cover-card__title {

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react'
+import type { MouseEvent } from 'react'
+import { Box, Menu, MenuItem, Popover, Slider, Typography } from '@mui/material'
+import { Check, Star } from 'lucide-react'
 import type { BookEntry, BookStatus } from '../../model/book.types'
 import styles from './BookCoverCard.module.scss'
 
@@ -15,20 +19,74 @@ const STATUS_CLASS: Record<BookStatus, string | undefined> = {
   DROPPED: styles['cover-card__status--dropped'],
 }
 
+/** Цвет точки статуса в поп-овере выбора — совпадает с цветом пилюли на карточке. */
+const STATUS_DOT_COLOR: Record<BookStatus, string> = {
+  WANT: '#999',
+  READING: '#5aa0c8',
+  DONE: 'var(--color-primary, #4e7b6a)',
+  DROPPED: '#b94040',
+}
+
+/** Варианты статуса для быстрого выбора в поп-овере. */
+const STATUS_OPTIONS = Object.entries(STATUS_LABEL).map(([value, label]) => ({
+  value: value as BookStatus,
+  label,
+}))
+
 /** Цвет кольца и числа в бейдже оценки — по диапазону. */
 function scoreColor(rating: number): string {
-  if (rating >= 8) return 'var(--color-primary, #4e7b6a)'
-  if (rating >= 6) return 'var(--color-warning, #c49a3a)'
+  // Цвета фиксированы (не из токенов темы) — это семантическая «светофорная»
+  // шкала оценки, а не акцентный цвет, поэтому она не должна зависеть от темы.
+  if (rating >= 8) return '#5e9b84'
+  if (rating >= 6) return '#c49a3a'
   return '#b94040'
+}
+
+/** Путь звезды для рядов закрашиваемых звёзд оценки. */
+const STAR_PATH = 'm12 3 2.6 5.6 6.1.6-4.6 4.2 1.3 6L12 16.5 6.6 19.4l1.3-6L3.3 9.2l6.1-.6z'
+
+/**
+ * Ряд из 5 звёзд, закрашенных пропорционально оценке по шкале 1–10
+ * (10 — все 5 звёзд, 5 — 2.5 звезды и т.д.).
+ */
+function StarRow({ value, gradientPrefix }: { value: number; gradientPrefix: string }) {
+  const fiveScale = value / 2
+  const color = scoreColor(value)
+
+  return (
+    <Box sx={{ display: 'flex', justifyContent: 'space-between' }}>
+      {[1, 2, 3, 4, 5].map((i) => {
+        const fill = Math.max(0, Math.min(1, fiveScale - (i - 1)))
+        const gradientId = `${gradientPrefix}-${i}`
+        return (
+          <svg key={i} width={32} height={32} viewBox="0 0 24 24">
+            <defs>
+              <linearGradient id={gradientId}>
+                <stop offset={`${fill * 100}%`} stopColor={color} />
+                <stop offset={`${fill * 100}%`} stopColor="rgba(150,150,150,0.3)" />
+              </linearGradient>
+            </defs>
+            <path d={STAR_PATH} fill={`url(#${gradientId})`} />
+          </svg>
+        )
+      })}
+    </Box>
+  )
 }
 
 /**
  * Круглый бейдж с оценкой (или плейсхолдер если книга не оценена).
  */
-function ScoreBadge({ rating }: { rating: number | null }) {
+function ScoreBadge({
+  rating,
+  onClick,
+}: {
+  rating: number | null
+  onClick: (e: MouseEvent<HTMLElement>) => void
+}) {
   if (rating === null) {
     return (
-      <div className={styles['cover-card__score']}>
+      <div className={styles['cover-card__score']} onClick={onClick}>
         <span
           className={`${styles['cover-card__score-value']} ${styles['cover-card__score-value--empty']}`}
         >
@@ -44,7 +102,7 @@ function ScoreBadge({ rating }: { rating: number | null }) {
   const color = scoreColor(rating)
 
   return (
-    <div className={styles['cover-card__score']} title={`Оценка ${rating}/10`}>
+    <div className={styles['cover-card__score']} onClick={onClick} title={`Оценка ${rating}/10`}>
       <svg className={styles['cover-card__score-ring']} width="34" height="34" viewBox="0 0 34 34">
         <circle
           cx="17"
@@ -66,7 +124,11 @@ function ScoreBadge({ rating }: { rating: number | null }) {
           strokeDashoffset={offset}
         />
       </svg>
-      <span className={styles['cover-card__score-value']}>{rating}</span>
+      {rating === 10 ? (
+        <Star size={14} fill={color} stroke="none" />
+      ) : (
+        <span className={styles['cover-card__score-value']}>{rating}</span>
+      )}
     </div>
   )
 }
@@ -77,30 +139,65 @@ function ScoreBadge({ rating }: { rating: number | null }) {
 interface BookCoverCardProps {
   /** Запись пользователя с данными книги. */
   entry: BookEntry
+  /** Клик по карточке вне статуса и рейтинга — открывает редактирование всех полей. */
+  onEdit?: () => void
+  /** Выбор статуса в быстром поп-овере. */
+  onStatusChange?: (status: BookStatus) => void
+  /** Выбор оценки в быстром поп-овере. */
+  onRatingChange?: (rating: number) => void
 }
 
 /**
  * Карточка книги в стиле «обложка» — альтернативный вид BookCard.
+ * Клик по статусу или оценке открывает быстрый выбор этого поля,
+ * клик по остальной области карточки — открывает полное редактирование.
  */
-export const BookCoverCard = ({ entry }: BookCoverCardProps) => {
+export const BookCoverCard = ({
+  entry,
+  onEdit,
+  onStatusChange,
+  onRatingChange,
+}: BookCoverCardProps) => {
   const { book, status, rating, progress } = entry
+  const [statusAnchor, setStatusAnchor] = useState<HTMLElement | null>(null)
+  const [ratingAnchor, setRatingAnchor] = useState<HTMLElement | null>(null)
+  // Черновое значение слайдера — обновляется при перетаскивании,
+  // а мутация отправляется только когда пользователь отпускает слайдер.
+  const [ratingDraft, setRatingDraft] = useState(rating ?? 5)
 
   const progressPct =
     status === 'READING' && progress !== null && book.pageCount
       ? Math.min(100, Math.round((progress / book.pageCount) * 100))
       : null
 
+  /** Открывает поп-овер выбора статуса, не давая клику дойти до редактирования всей карточки. */
+  const handleStatusClick = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation()
+    setStatusAnchor(e.currentTarget)
+  }
+
+  /** Открывает поп-овер выбора оценки, не давая клику дойти до редактирования всей карточки. */
+  const handleRatingClick = (e: MouseEvent<HTMLElement>) => {
+    e.stopPropagation()
+    setRatingDraft(rating ?? 5)
+    setRatingAnchor(e.currentTarget)
+  }
+
   return (
-    <div className={styles['cover-card']}>
+    <div className={styles['cover-card']} onClick={onEdit}>
       <div className={styles['cover-card__cover']}>
-        <ScoreBadge rating={rating} />
+        {rating === 10 && <div className={styles['cover-card__gold-ring']} />}
+        <ScoreBadge rating={rating} onClick={handleRatingClick} />
         <div className={styles['cover-card__title']}>{book.title}</div>
         <div className={styles['cover-card__author']}>{book.author}</div>
       </div>
 
       <div className={styles['cover-card__footer']}>
         <p className={styles['cover-card__footer-title']}>{book.title}</p>
-        <span className={`${styles['cover-card__status']} ${STATUS_CLASS[status]}`}>
+        <span
+          className={`${styles['cover-card__status']} ${STATUS_CLASS[status]}`}
+          onClick={handleStatusClick}
+        >
           <span className={styles['cover-card__status-dot']} />
           {STATUS_LABEL[status]}
         </span>
@@ -113,6 +210,68 @@ export const BookCoverCard = ({ entry }: BookCoverCardProps) => {
           </div>
         )}
       </div>
+
+      <Menu
+        anchorEl={statusAnchor}
+        open={!!statusAnchor}
+        onClose={() => setStatusAnchor(null)}
+        slotProps={{ list: { dense: true } }}
+      >
+        {STATUS_OPTIONS.map((option) => (
+          <MenuItem
+            key={option.value}
+            selected={option.value === status}
+            sx={{ display: 'flex', alignItems: 'center', gap: 1, minWidth: 160 }}
+            onClick={(e) => {
+              e.stopPropagation()
+              onStatusChange?.(option.value)
+              setStatusAnchor(null)
+            }}
+          >
+            <Box
+              sx={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                flexShrink: 0,
+                bgcolor: STATUS_DOT_COLOR[option.value],
+              }}
+            />
+            <Box sx={{ flex: 1, fontSize: 13 }}>{option.label}</Box>
+            {option.value === status && <Check size={14} />}
+          </MenuItem>
+        ))}
+      </Menu>
+
+      <Popover
+        anchorEl={ratingAnchor}
+        open={!!ratingAnchor}
+        onClose={() => setRatingAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Box sx={{ width: 200, pt: 2, px: 2, pb: 0.5 }} onClick={(e) => e.stopPropagation()}>
+          <Box sx={{ mb: 1 }}>
+            <StarRow value={ratingDraft} gradientPrefix={`rate-${entry.id}`} />
+          </Box>
+          <Typography align="center" sx={{ fontWeight: 600, mb: 0.5 }}>
+            {ratingDraft}{' '}
+            <Typography component="span" variant="caption" color="text.secondary">
+              / 10
+            </Typography>
+          </Typography>
+          <Slider
+            value={ratingDraft}
+            min={1}
+            max={10}
+            step={1}
+            onChange={(_, value) => setRatingDraft(value as number)}
+            onChangeCommitted={(_, value) => {
+              onRatingChange?.(value as number)
+              setRatingAnchor(null)
+            }}
+          />
+        </Box>
+      </Popover>
     </div>
   )
 }

--- a/apps/web/src/features/book/index.ts
+++ b/apps/web/src/features/book/index.ts
@@ -14,4 +14,4 @@ export type {
   CreateBookEntryDto,
   UpdateBookEntryDto,
 } from './api/booksApi'
-export { AddBookDialog } from './ui/AddBookDialog/AddBookDialog'
+export { BookFormDialog } from './ui/BookFormDialog/BookFormDialog'

--- a/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
+++ b/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import {
   Dialog,
@@ -11,8 +11,13 @@ import {
   Stack,
   Typography,
 } from '@mui/material'
-import type { BookStatus } from '@/entities/book'
-import { useCreateBookMutation, useCreateEntryMutation } from '../../api/booksApi'
+import type { BookEntry, BookStatus } from '@/entities/book'
+import {
+  useCreateBookMutation,
+  useCreateEntryMutation,
+  useUpdateBookMutation,
+  useUpdateEntryMutation,
+} from '../../api/booksApi'
 
 /** Варианты статуса книги для выбора в форме. */
 const STATUS_OPTIONS: { value: BookStatus; label: string }[] = [
@@ -23,9 +28,9 @@ const STATUS_OPTIONS: { value: BookStatus; label: string }[] = [
 ]
 
 /**
- * Значения полей формы добавления книги.
+ * Значения полей формы добавления/редактирования книги.
  */
-interface AddBookFormValues {
+interface BookFormValues {
   /** Название книги. */
   title: string
   /** Автор книги. */
@@ -34,39 +39,59 @@ interface AddBookFormValues {
   coverUrl: string
   /** Количество страниц (строка из инпута, переводится в число при отправке). */
   pageCount: string
-  /** Статус, с которым книга добавляется в список. */
+  /** Статус книги в списке пользователя. */
   status: BookStatus
+  /** Оценка от 1 до 10 (строка из инпута, только при редактировании). */
+  rating: string
 }
 
 /** Начальные значения формы добавления книги. */
-const DEFAULT_VALUES: AddBookFormValues = {
+const DEFAULT_VALUES: BookFormValues = {
   title: '',
   author: '',
   coverUrl: '',
   pageCount: '',
   status: 'WANT',
+  rating: '',
 }
 
 /** Значение автора, если поле оставлено пустым. */
 const UNKNOWN_AUTHOR = 'Автор неизвестен'
 
+/** Преобразует существующую запись в значения формы редактирования. */
+function entryToFormValues(entry: BookEntry): BookFormValues {
+  return {
+    title: entry.book.title,
+    author: entry.book.author,
+    coverUrl: entry.book.coverUrl ?? '',
+    pageCount: entry.book.pageCount ? String(entry.book.pageCount) : '',
+    status: entry.status,
+    rating: entry.rating ? String(entry.rating) : '',
+  }
+}
+
 /**
- * Пропсы AddBookDialog.
+ * Пропсы BookFormDialog.
  */
-interface AddBookDialogProps {
+interface BookFormDialogProps {
   /** Открыта ли модалка. */
   open: boolean
   /** Закрытие модалки. */
   onClose: () => void
+  /** Редактируемая запись. Если не передана — модалка работает в режиме добавления. */
+  entry?: BookEntry
 }
 
 /**
- * Модалка добавления книги — создаёт книгу в каталоге и сразу запись пользователя.
+ * Модалка добавления новой книги или редактирования существующей записи пользователя.
  */
-export const AddBookDialog = ({ open, onClose }: AddBookDialogProps) => {
+export const BookFormDialog = ({ open, onClose, entry }: BookFormDialogProps) => {
+  const isEdit = !!entry
   const [error, setError] = useState<string | null>(null)
   const [createBook] = useCreateBookMutation()
   const [createEntry] = useCreateEntryMutation()
+  const [updateBook] = useUpdateBookMutation()
+  const [updateEntry] = useUpdateEntryMutation()
 
   const {
     register,
@@ -74,47 +99,68 @@ export const AddBookDialog = ({ open, onClose }: AddBookDialogProps) => {
     control,
     reset,
     formState: { errors, isValid, isSubmitting },
-  } = useForm<AddBookFormValues>({
+  } = useForm<BookFormValues>({
     defaultValues: DEFAULT_VALUES,
     mode: 'onChange',
   })
 
+  // При каждом открытии модалки заполняем форму данными редактируемой записи
+  // (либо пустыми значениями для добавления) — компонент не размонтируется между открытиями.
+  useEffect(() => {
+    if (open) {
+      reset(entry ? entryToFormValues(entry) : DEFAULT_VALUES)
+    }
+  }, [open, entry, reset])
+
   /**
-   * Функция закрытия модалки с очисткой формы.
+   * Функция закрытия модалки.
    */
   const handleClose = () => {
     if (isSubmitting) return
-    reset(DEFAULT_VALUES)
-    setError(null)
     onClose()
   }
 
   /**
-   * Функция отправки формы — создаёт книгу и сразу запись пользователя.
+   * Функция отправки формы — создаёт книгу и запись, либо сохраняет изменения существующей.
    */
-  const onSubmit = async (values: AddBookFormValues) => {
+  const onSubmit = async (values: BookFormValues) => {
     setError(null)
     try {
-      const book = await createBook({
+      const bookDto = {
         title: values.title.trim(),
         author: values.author.trim() || UNKNOWN_AUTHOR,
         ...(values.coverUrl.trim() && { coverUrl: values.coverUrl.trim() }),
         ...(values.pageCount && { pageCount: Number(values.pageCount) }),
-      }).unwrap()
+      }
 
-      await createEntry({ bookId: book.id, status: values.status }).unwrap()
+      if (entry) {
+        await updateBook({ id: entry.book.id, dto: bookDto }).unwrap()
+        await updateEntry({
+          id: entry.id,
+          dto: {
+            status: values.status,
+            ...(values.rating && { rating: Number(values.rating) }),
+          },
+        }).unwrap()
+      } else {
+        const book = await createBook(bookDto).unwrap()
+        await createEntry({ bookId: book.id, status: values.status }).unwrap()
+      }
 
-      reset(DEFAULT_VALUES)
       onClose()
     } catch {
-      setError('Не удалось добавить книгу. Попробуй ещё раз.')
+      setError(
+        isEdit
+          ? 'Не удалось сохранить изменения. Попробуй ещё раз.'
+          : 'Не удалось добавить книгу. Попробуй ещё раз.',
+      )
     }
   }
 
   return (
     <Dialog open={open} onClose={handleClose} fullWidth maxWidth="sm">
       <form onSubmit={handleSubmit(onSubmit)}>
-        <DialogTitle>Добавить книгу</DialogTitle>
+        <DialogTitle>{isEdit ? 'Редактировать книгу' : 'Добавить книгу'}</DialogTitle>
         <DialogContent>
           <Stack spacing={2} sx={{ mt: 1 }}>
             <TextField
@@ -151,6 +197,16 @@ export const AddBookDialog = ({ open, onClose }: AddBookDialogProps) => {
               />
             </Stack>
 
+            {isEdit && (
+              <TextField
+                label="Оценка (1–10)"
+                type="number"
+                fullWidth
+                inputProps={{ min: 1, max: 10 }}
+                {...register('rating')}
+              />
+            )}
+
             {error && <Typography color="error">{error}</Typography>}
           </Stack>
         </DialogContent>
@@ -159,7 +215,7 @@ export const AddBookDialog = ({ open, onClose }: AddBookDialogProps) => {
             Отмена
           </Button>
           <Button type="submit" variant="contained" disabled={!isValid || isSubmitting}>
-            Добавить
+            {isEdit ? 'Сохранить' : 'Добавить'}
           </Button>
         </DialogActions>
       </form>

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -10,7 +10,8 @@ import {
   Button,
 } from '@mui/material'
 import { BookCard, BookCoverCard } from '@/entities/book'
-import { AddBookDialog, useGetMyEntriesQuery } from '@/features/book'
+import type { BookEntry } from '@/entities/book'
+import { BookFormDialog, useGetMyEntriesQuery, useUpdateEntryMutation } from '@/features/book'
 import { saveRedirectPath } from '@/shared/lib/redirectPath'
 import { useAppSelector } from '@/shared/lib/store'
 import styles from './LibraryPage.module.scss'
@@ -18,18 +19,33 @@ import styles from './LibraryPage.module.scss'
 /** Стиль отображения карточек книги. */
 type CardStyle = 'compact' | 'cover'
 
+/** Ключ для сохранения выбранного стиля карточек между визитами. */
+const CARD_STYLE_STORAGE_KEY = 'treqio_library_card_style'
+
 /**
  * Страница библиотеки пользователя.
  */
 export const LibraryPage = () => {
-  const [cardStyle, setCardStyle] = useState<CardStyle>('compact')
+  // Читаем сохранённый стиль синхронно при инициализации — иначе при перезагрузке
+  // страница на миг отрисуется с дефолтным стилем и тут же переключится на сохранённый.
+  const [cardStyle, setCardStyleState] = useState<CardStyle>(
+    () => (localStorage.getItem(CARD_STYLE_STORAGE_KEY) as CardStyle | null) ?? 'cover',
+  )
   const [addOpen, setAddOpen] = useState(false)
+  const [editEntry, setEditEntry] = useState<BookEntry | null>(null)
   const [guestPromptOpen, setGuestPromptOpen] = useState(false)
   const isGuest = useAppSelector((s) => s.auth.isGuest)
   const navigate = useNavigate()
   const { data, isLoading, isError } = useGetMyEntriesQuery()
+  const [updateEntry] = useUpdateEntryMutation()
   const entries = data ?? []
   const isEmpty = !isError && entries.length === 0
+
+  /** Меняет стиль карточек и сохраняет выбор в localStorage. */
+  const setCardStyle = (style: CardStyle) => {
+    setCardStyleState(style)
+    localStorage.setItem(CARD_STYLE_STORAGE_KEY, style)
+  }
 
   /** Открывает форму добавления книги, либо для гостя — предлагает войти. */
   const handleAddClick = () => {
@@ -117,15 +133,29 @@ export const LibraryPage = () => {
         <div className={styles['library__grid']}>
           {entries.map((entry) =>
             cardStyle === 'compact' ? (
-              <BookCard key={entry.id} entry={entry} />
+              <BookCard key={entry.id} entry={entry} onClick={() => setEditEntry(entry)} />
             ) : (
-              <BookCoverCard key={entry.id} entry={entry} />
+              <BookCoverCard
+                key={entry.id}
+                entry={entry}
+                onEdit={() => setEditEntry(entry)}
+                onStatusChange={(status) => updateEntry({ id: entry.id, dto: { status } })}
+                onRatingChange={(rating) => updateEntry({ id: entry.id, dto: { rating } })}
+              />
             ),
           )}
         </div>
       )}
 
-      <AddBookDialog open={addOpen} onClose={() => setAddOpen(false)} />
+      <BookFormDialog
+        key={editEntry?.id ?? (addOpen ? 'add' : 'closed')}
+        open={addOpen || !!editEntry}
+        entry={editEntry ?? undefined}
+        onClose={() => {
+          setAddOpen(false)
+          setEditEntry(null)
+        }}
+      />
 
       <Dialog open={guestPromptOpen} onClose={() => setGuestPromptOpen(false)}>
         <DialogTitle sx={{ pt: 3, px: 3 }}>Необходимо войти</DialogTitle>


### PR DESCRIPTION
Closes #122

## Что сделано
- `AddBookDialog` переименован в `BookFormDialog`, добавлен режим редактирования (предзаполнение, `updateBook`/`updateEntry` вместо `createBook`/`createEntry`, поле «Оценка»)
- `BookCard`: клик по карточке открывает редактирование всех полей
- `BookCoverCard`: клик по статусу — поп-овер списка статусов (точка + галочка у выбранного), клик по оценке — поп-овер со слайдером и звёздами (закраска синхронна со значением, цвет звёзд меняется зелёный/жёлтый/красный), клик по остальной области — полное редактирование
- Обложка `BookCoverCard`: градиент из primary/primary-dark темы + затемнение нижнего правого угла, семантические (не привязанные к теме) цвета шкалы оценки, золотое вращающееся кольцо-индикатор при оценке 10/10 (conic-gradient + `@property`, без скачущих углов)
- `LibraryPage`: выбранный стиль карточек (компактный/обложки) сохраняется в localStorage и восстанавливается без мигания при перезагрузке (по умолчанию — обложки)

## Тестирование
- [x] `tsc --noEmit` — без ошибок
- [x] `vitest run` — 12/12 тестов
- [x] `vite build` — собирается, SCSS компилируется