### PR TITLE
feat(web): табы статусов в библиотеке, общий словарь статусов, убраны игры из профиля

### DIFF
--- a/apps/web/src/entities/book/index.ts
+++ b/apps/web/src/entities/book/index.ts
@@ -1,3 +1,4 @@
 export { BookCard } from './ui/BookCard/BookCard'
 export { BookCoverCard } from './ui/BookCoverCard/BookCoverCard'
 export type { Book, BookEntry, BookStatus } from './model/book.types'
+export { STATUS_LABEL } from './model/book.types'

--- a/apps/web/src/entities/book/model/book.types.ts
+++ b/apps/web/src/entities/book/model/book.types.ts
@@ -4,6 +4,16 @@
 export type BookStatus = 'WANT' | 'READING' | 'DONE' | 'DROPPED'
 
 /**
+ * Человекочитаемые названия статусов книги.
+ */
+export const STATUS_LABEL: Record<BookStatus, string> = {
+  WANT: 'Хочу прочитать',
+  READING: 'Читаю',
+  DONE: 'Прочитано',
+  DROPPED: 'Брошено',
+}
+
+/**
  * Книга из общего каталога.
  */
 export interface Book {

--- a/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCard/BookCard.tsx
@@ -1,16 +1,10 @@
 import { Card, CardContent, CardMedia, Box, Typography, Chip } from '@mui/material'
 import { lighten, darken } from '@mui/material/styles'
 import { BookOpen, Star } from 'lucide-react'
+import { STATUS_LABEL } from '../../model/book.types'
 import type { BookEntry, BookStatus } from '../../model/book.types'
 
 const COVER_HEIGHT = 170
-
-const STATUS_LABEL: Record<BookStatus, string> = {
-  WANT: 'Хочу прочитать',
-  READING: 'Читаю',
-  DONE: 'Прочитал',
-  DROPPED: 'Брошено',
-}
 
 const STATUS_COLOR: Record<BookStatus, 'default' | 'info' | 'success' | 'error'> = {
   WANT: 'default',

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -2,15 +2,9 @@ import { useState } from 'react'
 import type { MouseEvent } from 'react'
 import { Box, Menu, MenuItem, Popover, Rating, Slider, Typography } from '@mui/material'
 import { Check, Star } from 'lucide-react'
+import { STATUS_LABEL } from '../../model/book.types'
 import type { BookEntry, BookStatus } from '../../model/book.types'
 import styles from './BookCoverCard.module.scss'
-
-const STATUS_LABEL: Record<BookStatus, string> = {
-  WANT: 'Хочу прочитать',
-  READING: 'Читаю',
-  DONE: 'Прочитал',
-  DROPPED: 'Брошено',
-}
 
 const STATUS_CLASS: Record<BookStatus, string | undefined> = {
   WANT: styles['cover-card__status--want'],

--- a/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
+++ b/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
@@ -17,6 +17,7 @@ import {
   IconButton,
 } from '@mui/material'
 import { X } from 'lucide-react'
+import { STATUS_LABEL } from '@/entities/book'
 import type { BookEntry, BookStatus } from '@/entities/book'
 import {
   useCreateBookMutation,
@@ -28,12 +29,9 @@ import {
 import type { UpdateBookEntryDto } from '../../api/booksApi'
 
 /** Варианты статуса книги для выбора в форме. */
-const STATUS_OPTIONS: { value: BookStatus; label: string }[] = [
-  { value: 'WANT', label: 'Хочу прочитать' },
-  { value: 'READING', label: 'Читаю' },
-  { value: 'DONE', label: 'Прочитал' },
-  { value: 'DROPPED', label: 'Брошено' },
-]
+const STATUS_OPTIONS: { value: BookStatus; label: string }[] = Object.entries(STATUS_LABEL).map(
+  ([value, label]) => ({ value: value as BookStatus, label }),
+)
 
 /** Цвет точки статуса — совпадает с пилюлей статуса на BookCoverCard. */
 const STATUS_DOT_COLOR: Record<BookStatus, string> = {
@@ -64,7 +62,7 @@ interface BookFormValues {
   pageCount: string
   /** Статус книги в списке пользователя. */
   status: BookStatus
-  /** Оценка от 1 до 10 (строка из инпута, показывается при статусе «Прочитал»). */
+  /** Оценка от 1 до 10 (строка из инпута, показывается при статусе «Прочитано»). */
   rating: string
   /** Текущая/прочитанная страница (строка из инпута). */
   progress: string
@@ -115,7 +113,7 @@ interface BookFormDialogProps {
 
 /**
  * Модалка добавления новой книги или редактирования существующей записи пользователя.
- * Оценка показывается при статусе «Прочитал», прогресс — при «Читаю» (слайдер)
+ * Оценка показывается при статусе «Прочитано», прогресс — при «Читаю» (слайдер)
  * или «Брошено» (необязательный ввод прочитанных страниц).
  */
 export const BookFormDialog = ({ open, onClose, entry }: BookFormDialogProps) => {

--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -67,6 +67,50 @@ $bp-sm: 600px;
   }
 }
 
+// ─── Табы фильтра по статусу ──────────────────────────────────────────────────
+
+.library__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 0 36px 12px;
+
+  @media (max-width: $bp-sm) {
+    padding: 0 20px 12px;
+  }
+}
+
+.library__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border: 1px solid var(--color-divider, #d5e4d8);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--color-text-2, #666);
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+  &:hover {
+    border-color: var(--color-primary, #4e7b6a);
+  }
+
+  &--active {
+    background: var(--color-primary, #4e7b6a);
+    border-color: var(--color-primary, #4e7b6a);
+    color: white;
+  }
+}
+
+.library__tab-count {
+  font-size: 11px;
+  opacity: 0.75;
+}
+
 // ─── Лейбл-строка и переключатель стиля карточек ─────────────────────────────
 
 .library__label-row {

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -9,8 +9,8 @@ import {
   DialogActions,
   Button,
 } from '@mui/material'
-import { BookCard, BookCoverCard } from '@/entities/book'
-import type { BookEntry } from '@/entities/book'
+import { BookCard, BookCoverCard, STATUS_LABEL } from '@/entities/book'
+import type { BookEntry, BookStatus } from '@/entities/book'
 import { BookFormDialog, useGetMyEntriesQuery, useUpdateEntryMutation } from '@/features/book'
 import { saveRedirectPath } from '@/shared/lib/redirectPath'
 import { useAppSelector } from '@/shared/lib/store'
@@ -21,6 +21,15 @@ type CardStyle = 'compact' | 'cover'
 
 /** Ключ для сохранения выбранного стиля карточек между визитами. */
 const CARD_STYLE_STORAGE_KEY = 'treqio_library_card_style'
+
+/** Фильтр по статусу записи — добавляет вариант «Все» к статусам книги. */
+type StatusFilter = BookStatus | 'ALL'
+
+/** Табы фильтра по статусу над сеткой карточек. */
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'ALL', label: 'Все' },
+  ...Object.entries(STATUS_LABEL).map(([value, label]) => ({ value: value as BookStatus, label })),
+]
 
 /**
  * Страница библиотеки пользователя.
@@ -34,12 +43,16 @@ export const LibraryPage = () => {
   const [addOpen, setAddOpen] = useState(false)
   const [editEntry, setEditEntry] = useState<BookEntry | null>(null)
   const [guestPromptOpen, setGuestPromptOpen] = useState(false)
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL')
   const isGuest = useAppSelector((s) => s.auth.isGuest)
   const navigate = useNavigate()
   const { data, isLoading, isError } = useGetMyEntriesQuery()
   const [updateEntry] = useUpdateEntryMutation()
   const entries = data ?? []
   const isEmpty = !isError && entries.length === 0
+  const filteredEntries =
+    statusFilter === 'ALL' ? entries : entries.filter((entry) => entry.status === statusFilter)
+  const isFilteredEmpty = !isEmpty && filteredEntries.length === 0
 
   /** Меняет стиль карточек и сохраняет выбор в localStorage. */
   const setCardStyle = (style: CardStyle) => {
@@ -74,9 +87,30 @@ export const LibraryPage = () => {
         </button>
       </div>
 
+      {!isError && !isEmpty && (
+        <div className={styles['library__tabs']}>
+          {STATUS_TABS.map((tab) => {
+            const count =
+              tab.value === 'ALL'
+                ? entries.length
+                : entries.filter((e) => e.status === tab.value).length
+            return (
+              <button
+                key={tab.value}
+                className={`${styles['library__tab']} ${statusFilter === tab.value ? styles['library__tab--active'] : ''}`}
+                onClick={() => setStatusFilter(tab.value)}
+              >
+                {tab.label}
+                <span className={styles['library__tab-count']}>{count}</span>
+              </button>
+            )
+          })}
+        </div>
+      )}
+
       {!isError && (
         <div className={styles['library__label-row']}>
-          <span className={styles['library__label']}>{entries.length} книг</span>
+          <span className={styles['library__label']}>{filteredEntries.length} книг</span>
 
           <div className={styles['library__style-toggle']}>
             <button
@@ -129,9 +163,16 @@ export const LibraryPage = () => {
             </button>
           </div>
         </div>
+      ) : isFilteredEmpty ? (
+        <div className={styles['library__empty']}>
+          <div className={styles['library__empty-icon']}>
+            <BookOpen size={48} />
+          </div>
+          <p className={styles['library__empty-text']}>Нет книг с этим статусом</p>
+        </div>
       ) : (
         <div className={styles['library__grid']}>
-          {entries.map((entry) =>
+          {filteredEntries.map((entry) =>
             cardStyle === 'compact' ? (
               <BookCard key={entry.id} entry={entry} onClick={() => setEditEntry(entry)} />
             ) : (

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -234,51 +234,6 @@ $bp-md: 900px;
   }
 }
 
-// ─── Табы категорий ───────────────────────────────────────────────────────────
-
-.category-tabs {
-  display: flex;
-  gap: 4px;
-  padding: 4px;
-  background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
-  border-radius: 12px;
-  width: fit-content;
-
-  @media (max-width: $bp-sm) {
-    width: 100%;
-  }
-}
-
-.category-tab {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 8px 16px;
-  border-radius: 8px;
-  border: none;
-  background: transparent;
-  color: var(--color-text-2, #666);
-  font-size: 13px;
-  font-weight: 500;
-  font-family: inherit;
-  cursor: pointer;
-  transition:
-    background 0.15s,
-    color 0.15s;
-  flex: 1;
-  justify-content: center;
-
-  &:hover {
-    color: var(--color-text, inherit);
-  }
-
-  &--active {
-    background: var(--color-paper, white);
-    color: var(--color-primary, #4e7b6a);
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
-  }
-}
-
 // ─── Строка статистики ────────────────────────────────────────────────────────
 
 .stats-row {

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
-import { BookOpen, Gamepad2, Filter, Pencil, Check, X, LogIn, LogOut } from 'lucide-react'
+import { BookOpen, Filter, Pencil, Check, X, LogIn, LogOut } from 'lucide-react'
 import { useNavigate } from 'react-router'
+import { STATUS_LABEL } from '@/entities/book'
+import type { BookStatus } from '@/entities/book'
 import { useGetMeQuery, useUpdateMeMutation, useLogoutMutation } from '@/features/user'
 import { DISPLAY_NAME_MAX } from '@/features/user/api/constraints'
 import { setGuestDisplayName } from '@/features/guest'
@@ -10,23 +12,10 @@ import styles from './ProfilePage.module.scss'
 
 const DEFAULT_DISPLAY_NAME = 'Мечтатель'
 
-type Category = 'books' | 'games'
-type BookStatus = 'want' | 'reading' | 'done' | 'dropped'
-type GameStatus = 'want' | 'playing' | 'done' | 'dropped'
-
-const BOOK_STATUSES: { id: BookStatus; label: string }[] = [
-  { id: 'want', label: 'Хочу читать' },
-  { id: 'reading', label: 'Читаю' },
-  { id: 'done', label: 'Прочитал' },
-  { id: 'dropped', label: 'Брошено' },
-]
-
-const GAME_STATUSES: { id: GameStatus; label: string }[] = [
-  { id: 'want', label: 'Хочу пройти' },
-  { id: 'playing', label: 'Играю' },
-  { id: 'done', label: 'Прошёл' },
-  { id: 'dropped', label: 'Брошено' },
-]
+/** Табы статусов в строке статистики. */
+const STATUS_TABS: { value: BookStatus; label: string }[] = Object.entries(STATUS_LABEL).map(
+  ([value, label]) => ({ value: value as BookStatus, label }),
+)
 
 /**
  * Страница профиля пользователя.
@@ -48,9 +37,7 @@ export const ProfilePage = () => {
     dispatch(logout())
     navigate('/login')
   }
-  const [category, setCategory] = useState<Category>('books')
-  const [bookStatus, setBookStatus] = useState<BookStatus>('want')
-  const [gameStatus, setGameStatus] = useState<GameStatus>('want')
+  const [statusFilter, setStatusFilter] = useState<BookStatus>('WANT')
   const [editingName, setEditingName] = useState(false)
   const [nameValue, setNameValue] = useState('')
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -107,17 +94,6 @@ export const ProfilePage = () => {
    */
   const handleCancelName = () => {
     setEditingName(false)
-  }
-
-  const statuses = category === 'books' ? BOOK_STATUSES : GAME_STATUSES
-  const activeStatus = category === 'books' ? bookStatus : gameStatus
-
-  /**
-   * Функция переключения статуса в текущей категории.
-   */
-  const handleStatusChange = (id: string) => {
-    if (category === 'books') setBookStatus(id as BookStatus)
-    else setGameStatus(id as GameStatus)
   }
 
   const displayName = isGuest
@@ -196,34 +172,16 @@ export const ProfilePage = () => {
           </button>
         </div>
 
-        {/* Табы категорий */}
-        <div className={styles['category-tabs']}>
-          <button
-            className={`${styles['category-tab']} ${category === 'books' ? styles['category-tab--active'] : ''}`}
-            onClick={() => setCategory('books')}
-          >
-            <BookOpen size={15} />
-            Книги
-          </button>
-          <button
-            className={`${styles['category-tab']} ${category === 'games' ? styles['category-tab--active'] : ''}`}
-            onClick={() => setCategory('games')}
-          >
-            <Gamepad2 size={15} />
-            Игры
-          </button>
-        </div>
-
         {/* Строка статистики */}
         <div className={styles['stats-row']}>
-          {statuses.map((s) => (
+          {STATUS_TABS.map((tab) => (
             <button
-              key={s.id}
-              className={`${styles['stat']} ${activeStatus === s.id ? styles['stat--active'] : ''}`}
-              onClick={() => handleStatusChange(s.id)}
+              key={tab.value}
+              className={`${styles['stat']} ${statusFilter === tab.value ? styles['stat--active'] : ''}`}
+              onClick={() => setStatusFilter(tab.value)}
             >
               <span className={styles['stat__value']}>0</span>
-              <span className={styles['stat__label']}>{s.label}</span>
+              <span className={styles['stat__label']}>{tab.label}</span>
             </button>
           ))}
           <div className={styles['stats-row__actions']}>
@@ -238,14 +196,10 @@ export const ProfilePage = () => {
       <div className={styles['grid-section']}>
         <div className={styles['empty-state']}>
           <div className={styles['empty-state__icon']}>
-            {category === 'books' ? <BookOpen size={48} /> : <Gamepad2 size={48} />}
+            <BookOpen size={48} />
           </div>
-          <p className={styles['empty-state__text']}>
-            {category === 'books' ? 'Список книг пуст' : 'Список игр пуст'}
-          </p>
-          <p className={styles['empty-state__sub']}>
-            Добавь первую {category === 'books' ? 'книгу' : 'игру'} в свою библиотеку
-          </p>
+          <p className={styles['empty-state__text']}>Список книг пуст</p>
+          <p className={styles['empty-state__sub']}>Добавь первую книгу в свою библиотеку</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Табы фильтра по статусу (Все/Хочу прочитать/Читаю/Прочитано/Брошено) над сеткой в LibraryPage с количеством записей по каждому статусу — фильтрация на фронте, без изменений API
- STATUS_LABEL вынесен в entities/book (рядом с типом BookStatus) и переиспользуется в BookCard, BookCoverCard, BookFormDialog, LibraryPage вместо локальных копий
- Из ProfilePage убран функционал игр (Category, GameStatus, табы Книги/Игры) — пока в приложении только книги; строка статистики теперь использует общий словарь статусов

## Test plan
- [x] tsc --noEmit без ошибок
- [x] eslint без ошибок (1 безвредный warning от watch())
- [x] vitest — 12/12 тестов
- [x] vite build — успешно
- [ ] Проверить в браузере: переключение табов в библиотеке фильтрует карточки и показывает корректные счётчики, профиль больше не показывает игры