### PR TITLE
История активности на странице профиля

### DIFF
--- a/apps/api/prisma/migrations/20260620210033_add_rating_updated_at/migration.sql
+++ b/apps/api/prisma/migrations/20260620210033_add_rating_updated_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BookEntry" ADD COLUMN     "ratingUpdatedAt" TIMESTAMP(3);

--- a/apps/api/prisma/migrations/20260621104011_add_status_updated_at/migration.sql
+++ b/apps/api/prisma/migrations/20260621104011_add_status_updated_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BookEntry" ADD COLUMN     "statusUpdatedAt" TIMESTAMP(3);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -94,6 +94,10 @@ model BookEntry {
   startDate  DateTime?
   /// Дата завершения чтения.
   finishDate DateTime?
+  /// Дата последнего изменения оценки.
+  ratingUpdatedAt DateTime?
+  /// Дата последнего изменения статуса.
+  statusUpdatedAt DateTime?
   /// Заметки пользователя.
   notes      String?
 

--- a/apps/api/src/books/books.service.ts
+++ b/apps/api/src/books/books.service.ts
@@ -1,9 +1,23 @@
 import { Injectable, NotFoundException } from '@nestjs/common'
 import { PrismaService } from '../prisma/prisma.service'
+import { BookStatus } from '../generated/prisma/client'
 import type { CreateBookDto } from './dto/create-book.dto'
 import type { UpdateBookDto } from './dto/update-book.dto'
 import type { CreateBookEntryDto } from './dto/create-book-entry.dto'
 import type { UpdateBookEntryDto } from './dto/update-book-entry.dto'
+
+/**
+ * Даты, которые проставляются автоматически при переходе записи в указанный
+ * статус — начало чтения при «Читаю», начало и завершение при «Прочитано».
+ */
+function autoStatusDates(
+  status: BookStatus | undefined,
+  now: Date,
+): { startDate?: Date; finishDate?: Date } {
+  if (status === BookStatus.READING) return { startDate: now }
+  if (status === BookStatus.DONE) return { startDate: now, finishDate: now }
+  return {}
+}
 
 /**
  * Сервис управления книгами и записями пользователя.
@@ -66,8 +80,9 @@ export class BooksService {
    * Создание записи о книге для пользователя.
    */
   createEntry(userId: string, dto: CreateBookEntryDto) {
+    const autoDates = autoStatusDates(dto.status, new Date())
     return this.prisma.bookEntry.create({
-      data: { userId, ...dto },
+      data: { userId, ...dto, ...autoDates },
       include: { book: true },
     })
   }
@@ -78,12 +93,35 @@ export class BooksService {
   async updateEntry(userId: string, entryId: string, dto: UpdateBookEntryDto) {
     const entry = await this.prisma.bookEntry.findUnique({ where: { id: entryId } })
     if (!entry || entry.userId !== userId) throw new NotFoundException('Запись не найдена')
+
+    // now общий для autoDates и ratingUpdatedAt: если статус и оценка
+    // меняются в одном запросе (например отметили книгу прочитанной сразу
+    // с оценкой), finishDate и ratingUpdatedAt совпадут до миллисекунды —
+    // на фронте по этому совпадению решают, показывать оценку отдельным
+    // событием истории или как часть события «прочитал».
+    const now = new Date()
+    // Авто-дата проставляется только если статус меняется и дата ещё не задана
+    // вручную — не перезаписывает уже существующие startDate/finishDate.
+    const autoDates = autoStatusDates(dto.status, now)
+    const ratingChanged = dto.rating !== undefined && dto.rating !== entry.rating
+    const statusChanged = dto.status !== undefined && dto.status !== entry.status
+
     return this.prisma.bookEntry.update({
       where: { id: entryId },
       data: {
         ...dto,
-        startDate: dto.startDate ? new Date(dto.startDate) : undefined,
-        finishDate: dto.finishDate ? new Date(dto.finishDate) : undefined,
+        startDate: dto.startDate
+          ? new Date(dto.startDate)
+          : entry.startDate === null
+            ? autoDates.startDate
+            : undefined,
+        finishDate: dto.finishDate
+          ? new Date(dto.finishDate)
+          : entry.finishDate === null
+            ? autoDates.finishDate
+            : undefined,
+        ratingUpdatedAt: ratingChanged ? now : undefined,
+        statusUpdatedAt: statusChanged ? now : undefined,
       },
       include: { book: true },
     })

--- a/apps/web/src/entities/book/model/book.types.ts
+++ b/apps/web/src/entities/book/model/book.types.ts
@@ -55,6 +55,10 @@ export interface BookEntry {
   startDate: string | null
   /** Дата завершения чтения. */
   finishDate: string | null
+  /** Дата последнего изменения оценки. */
+  ratingUpdatedAt: string | null
+  /** Дата последнего изменения статуса. */
+  statusUpdatedAt: string | null
   /** Заметки пользователя. */
   notes: string | null
   createdAt: string

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.module.scss
@@ -17,10 +17,8 @@
   inherits: false;
 }
 
-// Обёртка вокруг обложки без overflow:hidden — нужна чтобы золотое кольцо
-// (соседний элемент, не внутри обложки) могло чуть выходить за её границы
-// и перекрывать стык, а сама обложка при этом продолжала клипать свои
-// псевдоэлементы (корешок, текстура) по скруглённым углам.
+// Обёртка вокруг обложки — золотое кольцо рендерится здесь как сосед
+// обложки, а не её потомок, чтобы не клипаться её overflow:hidden.
 .cover-card__cover-frame {
   position: relative;
 }
@@ -74,30 +72,29 @@
 }
 
 // Идеальная оценка 10/10 — золотая «комета», бегущая по тонкому ободку вдоль
-// края обложки, как индикатор загрузки. Двухслойный background-clip вместо
-// mask-composite: внутренний слой (padding-box) повторяет градиент обложки —
-// на скруглённых углах padding-box корректно уменьшает радиус сам, без щели,
-// в отличие от связки mask content-box/border-box, где она была заметна.
-// Кольцо — сосед обложки (а не её потомок), поэтому inset чуть меньше нуля
-// не обрезается overflow:hidden самой обложки и слегка перекрывает её край.
+// края обложки. Маска (content-box + border-box, exclude) оставляет видимым
+// только ободок, середина остаётся прозрачной — обложка под кольцом видна
+// как обычно.
 .cover-card__gold-ring {
   position: absolute;
-  inset: -1.5px;
+  inset: 0;
   z-index: 3;
-  border: 4px solid transparent;
-  border-radius: 11px;
+  border-radius: 10px;
+  padding: 4px;
   pointer-events: none;
-  background:
-    linear-gradient(150deg, var(--color-primary, #4e7b6a), var(--color-primary-dark, #3a5c4f)) padding-box,
-    conic-gradient(
-      from var(--gold-angle),
-      rgba(255, 225, 150, 0) 0deg,
-      rgba(255, 225, 150, 0) 200deg,
-      rgba(255, 232, 170, 0.55) 270deg,
-      #ffe9a8 320deg,
-      #ffd24a 345deg,
-      rgba(255, 225, 150, 0) 360deg
-    ) border-box;
+  background: conic-gradient(
+    from var(--gold-angle),
+    rgba(255, 225, 150, 0) 0deg,
+    rgba(255, 225, 150, 0) 200deg,
+    rgba(255, 232, 170, 0.55) 270deg,
+    #ffe9a8 320deg,
+    #ffd24a 345deg,
+    rgba(255, 225, 150, 0) 360deg
+  );
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
   animation: cover-card-gold-spin 2.4s linear infinite;
   filter: drop-shadow(0 0 4px rgba(255, 210, 90, 0.35));
 
@@ -216,18 +213,22 @@
   .cover-card__status-dot { background: #5aa0c8; }
 }
 
+// Зелёный фиксирован (не из токенов темы, как в .cover-card__cover) — статус
+// «Прочитано» должен читаться как «готово» на любой палитре, а не сливаться
+// с акцентным цветом темы, который может быть синим, фиолетовым и т.д.
 .cover-card__status--done {
-  background: color-mix(in oklab, var(--color-primary, #4e7b6a) 16%, transparent);
-  color: var(--color-primary-dark, #3d6a55);
+  background: rgba(76, 175, 110, 0.16);
+  color: #3d8a5c;
 
-  .cover-card__status-dot { background: var(--color-primary, #4e7b6a); }
+  .cover-card__status-dot { background: #4caf6e; }
 }
 
+// Нейтральный, но отличимый от обычного цвета текста темы.
 .cover-card__status--want {
-  background: rgba(140, 140, 140, 0.16);
-  color: var(--color-text-2, #777);
+  background: rgba(123, 134, 148, 0.16);
+  color: #9c8a6a;
 
-  .cover-card__status-dot { background: #999; }
+  .cover-card__status-dot { background: #9c8a6a; }
 }
 
 .cover-card__status--dropped {

--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -13,11 +13,14 @@ const STATUS_CLASS: Record<BookStatus, string | undefined> = {
   DROPPED: styles['cover-card__status--dropped'],
 }
 
+/** Цвет статуса «Прочитано» — фиксированный зелёный, не зависит от акцентного цвета темы. */
+const STATUS_DONE_COLOR = '#4caf6e'
+
 /** Цвет точки статуса в поп-овере выбора — совпадает с цветом пилюли на карточке. */
 const STATUS_DOT_COLOR: Record<BookStatus, string> = {
-  WANT: '#999',
+  WANT: '#9c8a6a',
   READING: '#5aa0c8',
-  DONE: 'var(--color-primary, #4e7b6a)',
+  DONE: STATUS_DONE_COLOR,
   DROPPED: '#b94040',
 }
 

--- a/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.module.scss
+++ b/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.module.scss
@@ -120,18 +120,22 @@
   .table-row__status-dot { background: #5aa0c8; }
 }
 
+// Зелёный фиксирован (не из токенов темы) — статус «Прочитано» должен
+// читаться как «готово» на любой палитре, а не сливаться с акцентным
+// цветом темы, который может быть синим, фиолетовым и т.д.
 .table-row__status--done {
-  background: color-mix(in oklab, var(--color-primary, #4e7b6a) 16%, transparent);
-  color: var(--color-primary-dark, #3d6a55);
+  background: rgba(76, 175, 110, 0.16);
+  color: #3d8a5c;
 
-  .table-row__status-dot { background: var(--color-primary, #4e7b6a); }
+  .table-row__status-dot { background: #4caf6e; }
 }
 
+// Нейтральный, но отличимый от обычного цвета текста темы.
 .table-row__status--want {
-  background: rgba(140, 140, 140, 0.16);
-  color: var(--color-text-2, #777);
+  background: rgba(123, 134, 148, 0.16);
+  color: #9c8a6a;
 
-  .table-row__status-dot { background: #999; }
+  .table-row__status-dot { background: #9c8a6a; }
 }
 
 .table-row__status--dropped {

--- a/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.tsx
+++ b/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.tsx
@@ -13,11 +13,14 @@ const STATUS_CLASS: Record<BookStatus, string | undefined> = {
   DROPPED: styles['table-row__status--dropped'],
 }
 
+/** Цвет статуса «Прочитано» — фиксированный зелёный, не зависит от акцентного цвета темы. */
+const STATUS_DONE_COLOR = '#4caf6e'
+
 /** Цвет точки статуса в поп-овере выбора — совпадает с цветом пилюли в строке. */
 const STATUS_DOT_COLOR: Record<BookStatus, string> = {
-  WANT: '#999',
+  WANT: '#9c8a6a',
   READING: '#5aa0c8',
-  DONE: 'var(--color-primary, #4e7b6a)',
+  DONE: STATUS_DONE_COLOR,
   DROPPED: '#b94040',
 }
 

--- a/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
+++ b/apps/web/src/features/book/ui/BookFormDialog/BookFormDialog.tsx
@@ -108,7 +108,7 @@ interface BookFormDialogProps {
   /** Закрытие модалки. */
   onClose: () => void
   /** Редактируемая запись. Если не передана — модалка работает в режиме добавления. */
-  entry?: BookEntry
+  entry?: BookEntry | undefined
 }
 
 /**
@@ -346,7 +346,7 @@ export const BookFormDialog = ({ open, onClose, entry }: BookFormDialogProps) =>
                     name="progress"
                     control={control}
                     render={({ field }) => (
-                      <Stack direction="row" spacing={2} alignItems="center" sx={{ mt: 0.5 }}>
+                      <Stack direction="row" spacing={2} sx={{ alignItems: 'center', mt: 0.5 }}>
                         <Slider
                           value={field.value ? Number(field.value) : 0}
                           min={0}
@@ -387,12 +387,11 @@ export const BookFormDialog = ({ open, onClose, entry }: BookFormDialogProps) =>
                   render={({ field }) => {
                     const ratingValue = field.value ? Number(field.value) : 0
                     return (
-                      <Stack direction="row" alignItems="center" spacing={2}>
+                      <Stack direction="row" spacing={2} sx={{ alignItems: 'center' }}>
                         <Stack
                           direction="row"
-                          alignItems="center"
                           spacing={1}
-                          sx={{ flexShrink: 0 }}
+                          sx={{ alignItems: 'center', flexShrink: 0 }}
                         >
                           <Rating
                             value={ratingValue / 2}

--- a/apps/web/src/pages/home/HomePage.module.scss
+++ b/apps/web/src/pages/home/HomePage.module.scss
@@ -47,10 +47,10 @@ $bp-md: 900px;
 .home__layout-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  padding: 3px;
+  gap: 6px;
+  padding: 4px;
   background: var(--color-paper-2, rgba(0, 0, 0, 0.06));
-  border-radius: 10px;
+  border-radius: 11px;
   flex-shrink: 0;
 }
 
@@ -61,7 +61,7 @@ $bp-md: 900px;
   width: 32px;
   height: 32px;
   border: none;
-  border-radius: 7px;
+  border-radius: 8px;
   background: transparent;
   color: var(--color-text-2, #666);
   cursor: pointer;

--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -116,18 +116,12 @@ $bp-sm: 600px;
 .library__label-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   padding: 0 36px 4px;
 
   @media (max-width: $bp-sm) {
     padding: 0 20px 4px;
   }
-}
-
-.library__label {
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--color-text-2, #666);
 }
 
 .library__style-toggle {

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -110,8 +110,6 @@ export const LibraryPage = () => {
 
       {!isError && (
         <div className={styles['library__label-row']}>
-          <span className={styles['library__label']}>{filteredEntries.length} книг</span>
-
           <div className={styles['library__style-toggle']}>
             <button
               className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -1,6 +1,15 @@
 $bp-sm: 600px;
 $bp-md: 900px;
 
+// ─── Цвета событий в истории (node + verb используют одни и те же) ──────────────
+$history-added-color: #7b8694;
+$history-reading-color: #5aa0c8;
+$history-reading-text-color: #4a92bd;
+$history-done-color: #4caf6e;
+$history-dropped-color: #b94040;
+$history-rated-color: #c49a3a;
+$history-status-color: #8a6fc4;
+
 // ─── Страница ─────────────────────────────────────────────────────────────────
 
 .profile {
@@ -51,7 +60,9 @@ $bp-md: 900px;
   font-family: inherit;
   cursor: pointer;
   white-space: nowrap;
-  transition: background 0.15s, box-shadow 0.15s;
+  transition:
+    background 0.15s,
+    box-shadow 0.15s;
 
   &:hover {
     background: var(--color-chip-bg);
@@ -215,7 +226,6 @@ $bp-md: 900px;
   }
 }
 
-
 .name-counter {
   position: absolute;
   top: 26px;
@@ -234,99 +244,56 @@ $bp-md: 900px;
   }
 }
 
-// ─── Строка статистики ────────────────────────────────────────────────────────
+// ─── Табы (История / Статистика) ─────────────────────────────────────────────
 
-.stats-row {
+.tabs {
   display: flex;
-  align-items: center;
-  gap: 22px;
-  padding: 10px 0;
-  border-top: 1px solid var(--color-divider, #e0e0e0);
+  gap: 4px;
+  margin: 28px 0 0;
+  padding: 0 40px;
   border-bottom: 1px solid var(--color-divider, #e0e0e0);
 
   @media (max-width: $bp-sm) {
-    gap: 14px;
+    padding: 0 18px;
   }
 }
 
-.stat {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 1px;
-  cursor: pointer;
-  padding: 2px 4px;
-  border-radius: 6px;
-  transition: background 0.15s;
+.tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-2, #666);
+  position: relative;
   border: none;
   background: transparent;
   font-family: inherit;
-  text-align: left;
-
-  &:hover {
-    background: var(--color-paper-2, rgba(0, 0, 0, 0.04));
-  }
-
-  &--active .stat__value {
-    color: var(--color-primary, #4e7b6a);
-  }
-
-  &--active .stat__label {
-    color: var(--color-primary, #4e7b6a);
-  }
-}
-
-.stat__value {
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--color-text, inherit);
-  line-height: 1.2;
-}
-
-.stat__label {
-  font-size: 11px;
-  color: var(--color-text-2, #666);
-  white-space: nowrap;
-}
-
-.stats-row__actions {
-  margin-left: auto;
-  display: flex;
-  gap: 6px;
-}
-
-.icon-btn {
-  width: 34px;
-  height: 34px;
-  border-radius: 8px;
-  border: 1px solid var(--color-divider, #e0e0e0);
-  background: var(--color-paper, white);
-  color: var(--color-text-2, #666);
-  display: grid;
-  place-items: center;
   cursor: pointer;
-  transition:
-    border-color 0.15s,
-    color 0.15s;
+  transition: color 0.15s;
 
   &:hover {
-    border-color: var(--color-primary, #4e7b6a);
     color: var(--color-text, inherit);
   }
-}
 
-// ─── Сетка (пустое состояние) ─────────────────────────────────────────────────
+  &--active {
+    color: var(--color-text, inherit);
 
-.grid-section {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 20px 40px 60px;
-
-  @media (max-width: $bp-sm) {
-    padding: 16px 18px 100px;
+    &::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -1px;
+      height: 2px;
+      background: var(--color-primary, #4e7b6a);
+      border-radius: 2px;
+    }
   }
 }
+
+// ─── Пустое состояние (история/статистика) ───────────────────────────────────
 
 .empty-state {
   flex: 1;
@@ -352,4 +319,195 @@ $bp-md: 900px;
 .empty-state__sub {
   font-size: 13px;
   opacity: 0.7;
+}
+
+// ─── История (таймлайн) ──────────────────────────────────────────────────────
+
+.history {
+  display: flex;
+  flex-direction: column;
+  padding: 0 40px 40px;
+
+  @media (max-width: $bp-sm) {
+    padding: 0 18px 32px;
+  }
+}
+
+.history__day {
+  margin-bottom: 4px;
+}
+
+.history__date {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-3, #999);
+  padding: 8px 14px;
+  // Отрицательный margin-left — точки таймлайна сидят у самого левого края
+  // .history__day (left: -34px у узла), а скруглённый угол строки даты иначе
+  // оказывается правее их и кружок чуть высовывается из-под строки.
+  margin: 10px 0 6px -6px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--color-primary, #4e7b6a) 8%, var(--color-paper, white));
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.history__timeline {
+  position: relative;
+  padding-left: 34px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: 13px;
+    top: 4px;
+    bottom: 4px;
+    width: 2px;
+    background: var(--color-divider, #e0e0e0);
+    border-radius: 2px;
+  }
+}
+
+.history__event {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  // Точка на линии таймлайна (.history__node) — absolute с left:-34px,
+  // её положение считается от padding-box этого элемента и не зависит
+  // от величины padding, поэтому отступ можно увеличивать без сдвига точки.
+  padding: 10px 16px;
+}
+
+.history__node {
+  position: absolute;
+  left: -34px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: var(--color-paper, white);
+  border: 2px solid var(--color-divider, #e0e0e0);
+  z-index: 1;
+
+  &--added {
+    border-color: $history-added-color;
+    color: $history-added-color;
+  }
+
+  &--reading {
+    border-color: $history-reading-color;
+    color: $history-reading-color;
+  }
+
+  // Зелёный фиксирован (не из токенов темы) — см. STATUS_DONE_COLOR
+  // в BookCoverCard/BookTableRow, тот же цвет для согласованности.
+  &--done {
+    border-color: $history-done-color;
+    color: $history-done-color;
+  }
+
+  &--dropped {
+    border-color: $history-dropped-color;
+    color: $history-dropped-color;
+  }
+
+  &--rated {
+    border-color: $history-rated-color;
+    color: $history-rated-color;
+  }
+
+  &--status {
+    border-color: $history-status-color;
+    color: $history-status-color;
+  }
+}
+
+.history__cover {
+  position: relative;
+  width: 34px;
+  height: 48px;
+  border-radius: 5px;
+  flex-shrink: 0;
+  background: linear-gradient(
+    150deg,
+    var(--color-primary, #4e7b6a),
+    var(--color-primary-dark, #3a5c4f)
+  );
+  box-shadow: 0 3px 8px -4px rgba(0, 0, 0, 0.5);
+}
+
+.history__cover-rating {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 15px;
+  padding: 0 4px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--color-paper, white) 88%, transparent);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.history__body {
+  flex: 1;
+  min-width: 0;
+}
+
+.history__text {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-text, inherit);
+  overflow-wrap: break-word;
+}
+
+// Фиксированный серый (не --color-text-2, который у части тем имеет
+// цветной оттенок, а не нейтральный серый).
+.history__verb--added {
+  color: #888;
+  font-weight: 600;
+}
+
+.history__verb--reading {
+  color: $history-reading-text-color;
+  font-weight: 600;
+}
+
+.history__verb--done {
+  color: $history-done-color;
+  font-weight: 600;
+}
+
+.history__verb--dropped {
+  color: $history-dropped-color;
+  font-weight: 600;
+}
+
+.history__verb--rated {
+  color: $history-rated-color;
+  font-weight: 600;
+}
+
+.history__verb--status {
+  color: $history-status-color;
+  font-weight: 600;
+}
+
+.history__time {
+  font-size: 12px;
+  color: var(--color-text-3, #999);
+  flex-shrink: 0;
 }

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -1,21 +1,154 @@
 import { useState, useRef, useEffect } from 'react'
-import { BookOpen, Filter, Pencil, Check, X, LogIn, LogOut } from 'lucide-react'
+import {
+  ArrowRight,
+  BarChart3,
+  Check,
+  History,
+  LogIn,
+  LogOut,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Star,
+  X,
+} from 'lucide-react'
+import type { ComponentType } from 'react'
 import { useNavigate } from 'react-router'
 import { STATUS_LABEL } from '@/entities/book'
-import type { BookStatus } from '@/entities/book'
+import type { BookEntry, BookStatus } from '@/entities/book'
 import { useGetMeQuery, useUpdateMeMutation, useLogoutMutation } from '@/features/user'
 import { DISPLAY_NAME_MAX } from '@/features/user/api/constraints'
 import { setGuestDisplayName } from '@/features/guest'
 import { logout } from '@/features/auth'
+import { useGetMyEntriesQuery } from '@/features/book'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import styles from './ProfilePage.module.scss'
 
 const DEFAULT_DISPLAY_NAME = 'Мечтатель'
 
-/** Табы статусов в строке статистики. */
-const STATUS_TABS: { value: BookStatus; label: string }[] = Object.entries(STATUS_LABEL).map(
-  ([value, label]) => ({ value: value as BookStatus, label }),
-)
+/** Вкладка страницы профиля. */
+type ProfileTab = 'history' | 'stats'
+
+/** Тип события в истории — выводится из текущих полей записи, без отдельного журнала действий. */
+type HistoryEventType = 'ADDED' | 'READING' | 'DONE' | 'DROPPED' | 'RATED' | 'STATUS'
+
+/**
+ * Событие истории — производное от одной записи BookEntry на конкретную дату.
+ */
+interface HistoryEvent {
+  /** Тип события. */
+  type: HistoryEventType
+  /** Дата события (ISO). */
+  date: string
+  /** Запись, на основе которой построено событие. */
+  entry: BookEntry
+}
+
+/** Группа событий за один день — с готовым лейблом («Сегодня», «Вчера» или дата). */
+interface HistoryDayGroup {
+  /** Лейбл дня. */
+  label: string
+  /** События за этот день, от новых к старым. */
+  events: HistoryEvent[]
+}
+
+/** Глагол действия для текста события. */
+const HISTORY_VERB: Record<HistoryEventType, string> = {
+  ADDED: 'добавил новую книгу',
+  READING: 'начал читать',
+  DONE: 'прочитал',
+  DROPPED: 'забросил',
+  RATED: 'изменил оценку',
+  STATUS: 'изменил статус книги',
+}
+
+/** Иконка узла на таймлайне для каждого типа события. */
+const HISTORY_ICON: Record<HistoryEventType, ComponentType<{ size?: number }>> = {
+  ADDED: Plus,
+  READING: ArrowRight,
+  DONE: Check,
+  DROPPED: X,
+  RATED: Star,
+  STATUS: RefreshCw,
+}
+
+/** Цвет текста статуса — совпадает с цветом пилюли статуса в библиотеке. */
+const STATUS_TEXT_COLOR: Record<BookStatus, string> = {
+  WANT: '#9c8a6a',
+  READING: '#4a92bd',
+  DONE: '#3d8a5c',
+  DROPPED: '#b94040',
+}
+
+/** Цвет оценки — по диапазону, фиксирован, не зависит от темы (как в библиотеке). */
+function scoreColor(rating: number): string {
+  if (rating >= 8) return '#5e9b84'
+  if (rating >= 6) return '#c49a3a'
+  return '#b94040'
+}
+
+/** Цвет звезды идеальной оценки 10/10 — золотой, как в библиотеке. */
+const GOLD_COLOR = '#ffd24a'
+
+/** Оценку изменили не в момент завершения книги — нужно отдельное событие. */
+function hasSeparateRatingEvent(entry: BookEntry): boolean {
+  return !!entry.ratingUpdatedAt && entry.ratingUpdatedAt !== entry.finishDate
+}
+
+/**
+ * Статус менялся в момент, не совпадающий с startDate/finishDate (например
+ * откатили «Прочитано» обратно на «Читаю») — такой переход событиями
+ * READING/DONE/DROPPED не покрывается, нужно отдельное общее событие.
+ */
+function hasSeparateStatusEvent(entry: BookEntry): boolean {
+  if (!entry.statusUpdatedAt) return false
+  if (entry.statusUpdatedAt === entry.startDate) return false
+  if (entry.statusUpdatedAt === entry.finishDate) return false
+  return entry.status !== 'DROPPED'
+}
+
+/** Строит события истории из текущих полей записей — без отдельного журнала действий. */
+function buildHistoryEvents(entries: BookEntry[]): HistoryEvent[] {
+  const events: HistoryEvent[] = []
+  for (const entry of entries) {
+    events.push({ type: 'ADDED', date: entry.createdAt, entry })
+    if (entry.startDate) events.push({ type: 'READING', date: entry.startDate, entry })
+    if (entry.finishDate) events.push({ type: 'DONE', date: entry.finishDate, entry })
+    if (entry.status === 'DROPPED') {
+      events.push({ type: 'DROPPED', date: entry.statusUpdatedAt ?? entry.updatedAt, entry })
+    }
+    if (hasSeparateRatingEvent(entry)) {
+      events.push({ type: 'RATED', date: entry.ratingUpdatedAt as string, entry })
+    }
+    if (hasSeparateStatusEvent(entry)) {
+      events.push({ type: 'STATUS', date: entry.statusUpdatedAt as string, entry })
+    }
+  }
+  return events.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+}
+
+/** Лейбл дня события — «Сегодня», «Вчера» или дата в формате «12 июня». */
+function formatDayLabel(dateStr: string): string {
+  const date = new Date(dateStr)
+  const today = new Date()
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+  if (date.toDateString() === today.toDateString()) return 'Сегодня'
+  if (date.toDateString() === yesterday.toDateString()) return 'Вчера'
+  return date.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long' })
+}
+
+/** Группирует отсортированные по дате события по дням. */
+function groupEventsByDay(events: HistoryEvent[]): HistoryDayGroup[] {
+  const groups: HistoryDayGroup[] = []
+  for (const event of events) {
+    const label = formatDayLabel(event.date)
+    const lastGroup = groups[groups.length - 1]
+    if (lastGroup && lastGroup.label === label) lastGroup.events.push(event)
+    else groups.push({ label, events: [event] })
+  }
+  return groups
+}
 
 /**
  * Страница профиля пользователя.
@@ -28,6 +161,7 @@ export const ProfilePage = () => {
   const { data: user, isLoading } = useGetMeQuery(undefined, { skip: isGuest })
   const [updateMe, { isLoading: isSaving }] = useUpdateMeMutation()
   const [logoutMutation] = useLogoutMutation()
+  const { data: entries } = useGetMyEntriesQuery()
 
   /**
    * Функция выхода из аккаунта.
@@ -37,7 +171,7 @@ export const ProfilePage = () => {
     dispatch(logout())
     navigate('/login')
   }
-  const [statusFilter, setStatusFilter] = useState<BookStatus>('WANT')
+  const [activeTab, setActiveTab] = useState<ProfileTab>('history')
   const [editingName, setEditingName] = useState(false)
   const [nameValue, setNameValue] = useState('')
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -100,6 +234,7 @@ export const ProfilePage = () => {
     ? guestDisplayName || DEFAULT_DISPLAY_NAME
     : user?.displayName || user?.username || DEFAULT_DISPLAY_NAME
   const avatarLetter = displayName.charAt(0).toUpperCase()
+  const dayGroups = groupEventsByDay(buildHistoryEvents(entries ?? []))
 
   return (
     <div className={styles['profile']}>
@@ -171,37 +306,123 @@ export const ProfilePage = () => {
             {isGuest ? 'Войти' : 'Выйти'}
           </button>
         </div>
-
-        {/* Строка статистики */}
-        <div className={styles['stats-row']}>
-          {STATUS_TABS.map((tab) => (
-            <button
-              key={tab.value}
-              className={`${styles['stat']} ${statusFilter === tab.value ? styles['stat--active'] : ''}`}
-              onClick={() => setStatusFilter(tab.value)}
-            >
-              <span className={styles['stat__value']}>0</span>
-              <span className={styles['stat__label']}>{tab.label}</span>
-            </button>
-          ))}
-          <div className={styles['stats-row__actions']}>
-            <button className={styles['icon-btn']}>
-              <Filter size={15} />
-            </button>
-          </div>
-        </div>
       </div>
 
-      {/* Сетка — пустое состояние */}
-      <div className={styles['grid-section']}>
+      <div className={styles['tabs']}>
+        <button
+          className={`${styles['tab']} ${activeTab === 'history' ? styles['tab--active'] : ''}`}
+          onClick={() => setActiveTab('history')}
+        >
+          <History size={17} />
+          Активность
+        </button>
+        <button
+          className={`${styles['tab']} ${activeTab === 'stats' ? styles['tab--active'] : ''}`}
+          onClick={() => setActiveTab('stats')}
+        >
+          <BarChart3 size={17} />
+          Статистика
+        </button>
+      </div>
+
+      {activeTab === 'history' ? (
+        dayGroups.length === 0 ? (
+          <div className={styles['empty-state']}>
+            <div className={styles['empty-state__icon']}>
+              <History size={48} />
+            </div>
+            <p className={styles['empty-state__text']}>Активность пока пуста</p>
+            <p className={styles['empty-state__sub']}>
+              Добавляй книги и отмечай прогресс — здесь появятся события
+            </p>
+          </div>
+        ) : (
+          <div className={styles['history']}>
+            {dayGroups.map((group) => (
+              <div key={group.label} className={styles['history__day']}>
+                <div className={styles['history__date']}>{group.label}</div>
+                <div className={styles['history__timeline']}>
+                  {group.events.map((event, i) => {
+                    const Icon = HISTORY_ICON[event.type]
+                    const { rating } = event.entry
+                    const showsRating =
+                      rating !== null &&
+                      ((event.type === 'DONE' && !hasSeparateRatingEvent(event.entry)) ||
+                        event.type === 'RATED')
+                    return (
+                      <div
+                        key={`${event.entry.id}-${event.type}-${i}`}
+                        className={styles['history__event']}
+                      >
+                        <div
+                          className={`${styles['history__node']} ${styles[`history__node--${event.type.toLowerCase()}`]}`}
+                        >
+                          <Icon size={14} />
+                        </div>
+                        <div className={styles['history__cover']}>
+                          {showsRating && (
+                            <span
+                              className={styles['history__cover-rating']}
+                              style={{ color: rating === 10 ? GOLD_COLOR : scoreColor(rating) }}
+                            >
+                              <Star
+                                size={9}
+                                fill={rating === 10 ? GOLD_COLOR : scoreColor(rating)}
+                                stroke="none"
+                              />
+                              {rating}
+                            </span>
+                          )}
+                        </div>
+                        <div className={styles['history__body']}>
+                          <p className={styles['history__text']}>
+                            <span className={styles[`history__verb--${event.type.toLowerCase()}`]}>
+                              {HISTORY_VERB[event.type]}
+                            </span>{' '}
+                            <strong>«{event.entry.book.title}»</strong>
+                            {event.type === 'ADDED' && (
+                              <>
+                                {' '}
+                                <span className={styles['history__verb--added']}>
+                                  со статусом
+                                </span>{' '}
+                                <strong style={{ color: STATUS_TEXT_COLOR[event.entry.status] }}>
+                                  «{STATUS_LABEL[event.entry.status]}»
+                                </strong>
+                              </>
+                            )}
+                            {event.type === 'STATUS' && (
+                              <>
+                                {' → '}
+                                <strong style={{ color: STATUS_TEXT_COLOR[event.entry.status] }}>
+                                  «{STATUS_LABEL[event.entry.status]}»
+                                </strong>
+                              </>
+                            )}
+                          </p>
+                        </div>
+                        <span className={styles['history__time']}>
+                          {new Date(event.date).toLocaleTimeString('ru-RU', {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </span>
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            ))}
+          </div>
+        )
+      ) : (
         <div className={styles['empty-state']}>
           <div className={styles['empty-state__icon']}>
-            <BookOpen size={48} />
+            <BarChart3 size={48} />
           </div>
-          <p className={styles['empty-state__text']}>Список книг пуст</p>
-          <p className={styles['empty-state__sub']}>Добавь первую книгу в свою библиотеку</p>
+          <p className={styles['empty-state__text']}>Статистика появится здесь позже</p>
         </div>
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Что сделано
- Таб «Активность» на странице профиля — таймлайн событий по дням (добавил книгу, начал читать, прочитал, забросил, изменил оценку, изменил статус)
- Новые поля `ratingUpdatedAt`/`statusUpdatedAt` в `BookEntry` (миграции Prisma) — проставляются только при реальном изменении оценки/статуса
- Вкладка «Статистика» — заглушка, реализация отложена

## Попутные фиксы
- Золотое кольцо обложки при рейтинге 10/10 переведено на маску вместо background-clip (раньше перекрывало бейдж оценки и корешок книги)
- Статус «Прочитано» — фиксированный зелёный цвет вместо акцентного цвета темы
- Статус «Хочу прочитать» — единый нейтральный цвет в библиотеке и активности
- Переключатель вида на главной странице приведён к стилю библиотеки
- Убран счётчик количества книг в библиотеке
- tsc-фикс в BookFormDialog после обновления MUI до v9

## Тестирование
- [x] lint/typecheck/test/build зелёные для web и api
- [x] Визуальная проверка в браузере (история, библиотека, главная)