### PR TITLE
fix(web): мерцание скролла в библиотеке и текст статуса в активности

### DIFF
--- a/apps/api/src/books/books.service.ts
+++ b/apps/api/src/books/books.service.ts
@@ -80,9 +80,14 @@ export class BooksService {
    * Создание записи о книге для пользователя.
    */
   createEntry(userId: string, dto: CreateBookEntryDto) {
-    const autoDates = autoStatusDates(dto.status, new Date())
+    // createdAt и startDate/finishDate должны совпадать до миллисекунды, если
+    // книга создаётся сразу со статусом «Читаю»/«Прочитано» — иначе на фронте
+    // событие "добавил" и "начал читать" сортируются в случайном порядке
+    // (DB-время @default(now()) и App-время new Date() — это две разные засечки).
+    const now = new Date()
+    const autoDates = autoStatusDates(dto.status, now)
     return this.prisma.bookEntry.create({
-      data: { userId, ...dto, ...autoDates },
+      data: { userId, ...dto, createdAt: now, ...autoDates },
       include: { book: true },
     })
   }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,15 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Treqio</title>
-    <!--
-      Шрифт Inter подгружается с Google Fonts.
-      display=swap — страница показывает системный шрифт пока Inter грузится,
-      затем переключается. Это предотвращает блокировку рендера.
-    -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=optional"
       rel="stylesheet"
     />
   </head>

--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -490,6 +490,18 @@ $history-status-color: #8a6fc4;
   overflow-wrap: break-word;
 }
 
+// Пилюля статуса в тексте события — цветной тинт фона, как у статуса на
+// обложке в библиотеке, без точки. Цвет приходит через style.
+.history__status-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 // Фиксированный серый (не --color-text-2, который у части тем имеет
 // цветной оттенок, а не нейтральный серый).
 .history__verb--added {

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -90,6 +90,19 @@ function scoreColor(rating: number): string {
 /** Цвет звезды идеальной оценки 10/10 — золотой, как в библиотеке. */
 const GOLD_COLOR = '#ffd24a'
 
+/** Пилюля статуса в тексте события — цветной тинт фона, как у статуса на обложке в библиотеке. */
+function StatusChip({ status }: { status: BookStatus }) {
+  const color = STATUS_TEXT_COLOR[status]
+  return (
+    <span
+      className={styles['history__status-chip']}
+      style={{ color, background: `color-mix(in srgb, ${color} 16%, transparent)` }}
+    >
+      {STATUS_LABEL[status]}
+    </span>
+  )
+}
+
 /** Оценку изменили не в момент завершения книги — нужно отдельное событие. */
 function hasSeparateRatingEvent(entry: BookEntry): boolean {
   return !!entry.ratingUpdatedAt && entry.ratingUpdatedAt !== entry.finishDate
@@ -107,6 +120,37 @@ function hasSeparateStatusEvent(entry: BookEntry): boolean {
   return entry.status !== 'DROPPED'
 }
 
+/**
+ * Книга создана сразу со статусом «Читаю»/«Прочитано»/«Брошено» — рядом есть
+ * событие (начал читать/прочитал/забросил) с той же датой, оно уже называет
+ * статус, поэтому «со статусом X» в тексте добавления было бы дублированием.
+ */
+function hasAccompanyingCreationEvent(entry: BookEntry): boolean {
+  if (entry.startDate === entry.createdAt) return true
+  if (entry.finishDate === entry.createdAt) return true
+  if (
+    entry.status === 'DROPPED' &&
+    (entry.statusUpdatedAt ?? entry.createdAt) === entry.createdAt
+  ) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Порядок событий при одинаковой дате (книга создана сразу со статусом
+ * «Читаю»/«Прочитано» — даты совпадают до миллисекунды) — более «продвинутое»
+ * по читательскому пути событие показывается выше, как более актуальное.
+ */
+const HISTORY_TYPE_RANK: Record<HistoryEventType, number> = {
+  ADDED: 0,
+  READING: 1,
+  DONE: 2,
+  DROPPED: 2,
+  RATED: 3,
+  STATUS: 3,
+}
+
 /** Строит события истории из текущих полей записей — без отдельного журнала действий. */
 function buildHistoryEvents(entries: BookEntry[]): HistoryEvent[] {
   const events: HistoryEvent[] = []
@@ -115,7 +159,7 @@ function buildHistoryEvents(entries: BookEntry[]): HistoryEvent[] {
     if (entry.startDate) events.push({ type: 'READING', date: entry.startDate, entry })
     if (entry.finishDate) events.push({ type: 'DONE', date: entry.finishDate, entry })
     if (entry.status === 'DROPPED') {
-      events.push({ type: 'DROPPED', date: entry.statusUpdatedAt ?? entry.updatedAt, entry })
+      events.push({ type: 'DROPPED', date: entry.statusUpdatedAt ?? entry.createdAt, entry })
     }
     if (hasSeparateRatingEvent(entry)) {
       events.push({ type: 'RATED', date: entry.ratingUpdatedAt as string, entry })
@@ -124,7 +168,11 @@ function buildHistoryEvents(entries: BookEntry[]): HistoryEvent[] {
       events.push({ type: 'STATUS', date: entry.statusUpdatedAt as string, entry })
     }
   }
-  return events.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  return events.sort((a, b) => {
+    const dateDiff = new Date(b.date).getTime() - new Date(a.date).getTime()
+    if (dateDiff !== 0) return dateDiff
+    return HISTORY_TYPE_RANK[b.type] - HISTORY_TYPE_RANK[a.type]
+  })
 }
 
 /** Лейбл дня события — «Сегодня», «Вчера» или дата в формате «12 июня». */
@@ -381,23 +429,21 @@ export const ProfilePage = () => {
                               {HISTORY_VERB[event.type]}
                             </span>{' '}
                             <strong>«{event.entry.book.title}»</strong>
-                            {event.type === 'ADDED' && (
-                              <>
-                                {' '}
-                                <span className={styles['history__verb--added']}>
-                                  со статусом
-                                </span>{' '}
-                                <strong style={{ color: STATUS_TEXT_COLOR[event.entry.status] }}>
-                                  «{STATUS_LABEL[event.entry.status]}»
-                                </strong>
-                              </>
-                            )}
+                            {event.type === 'ADDED' &&
+                              !hasAccompanyingCreationEvent(event.entry) && (
+                                <>
+                                  {' '}
+                                  <span className={styles['history__verb--added']}>
+                                    со статусом
+                                  </span>{' '}
+                                  <StatusChip status={event.entry.status} />
+                                </>
+                              )}
                             {event.type === 'STATUS' && (
                               <>
-                                {' → '}
-                                <strong style={{ color: STATUS_TEXT_COLOR[event.entry.status] }}>
-                                  «{STATUS_LABEL[event.entry.status]}»
-                                </strong>
+                                {' '}
+                                <span className={styles['history__verb--status']}>на</span>{' '}
+                                <StatusChip status={event.entry.status} />
                               </>
                             )}
                           </p>


### PR DESCRIPTION
## Что сделано
- `display=optional` вместо `swap` для Inter — убирает подмену шрифта после первой отрисовки и связанный с ней сдвиг вёрстки (мерцающий скролл в библиотеке)
- Статус в активности отображается пилюлей с цветным тинтом фона вместо кавычек
- Текст смены статуса: «изменил статус книги «X» на [статус]» вместо стрелки без старого значения
- При создании книги сразу со статусом «Читаю»/«Прочитано»/«Брошено» текст добавления не дублирует статус — он уже виден в соседнем событии
- `createdAt` и `startDate`/`finishDate` при создании записи используют общий `now` вместо раздельных DB-time/App-time засечек — порядок событий с одинаковой датой теперь детерминирован (приоритет: добавил → начал читать → прочитал/забросил → оценка/статус)