### PR TITLE
Кольцо рейтинга вместо карточки-обложки в активности

### DIFF
--- a/apps/web/src/pages/profile/ProfilePage.module.scss
+++ b/apps/web/src/pages/profile/ProfilePage.module.scss
@@ -3,6 +3,7 @@ $bp-md: 900px;
 
 // ─── Цвета событий в истории (node + verb используют одни и те же) ──────────────
 $history-added-color: #7b8694;
+$history-added-text-color: #3f9d91;
 $history-reading-color: #5aa0c8;
 $history-reading-text-color: #4a92bd;
 $history-done-color: #4caf6e;
@@ -365,7 +366,8 @@ $history-status-color: #8a6fc4;
   // оказывается правее их и кружок чуть высовывается из-под строки.
   margin: 10px 0 6px -6px;
   border-radius: 10px;
-  background: color-mix(in srgb, var(--color-primary, #4e7b6a) 8%, var(--color-paper, white));
+  background: color-mix(in srgb, var(--color-primary, #4e7b6a) 14%, var(--color-paper, white));
+  border: 1px solid color-mix(in srgb, var(--color-primary, #4e7b6a) 20%, transparent);
   position: sticky;
   top: 0;
   z-index: 2;
@@ -445,37 +447,36 @@ $history-status-color: #8a6fc4;
   }
 }
 
-.history__cover {
+// Кольцо оценки — только просмотр (не как в библиотеке, там оно кликабельно).
+// Донат-форма через ::before с фоном страницы внутри — закрывает середину
+// conic-gradient, оставляя видимым только внешнее кольцо. inline-flex и
+// vertical-align — чтобы вписывалось в строку текста, не выходя за её пределы.
+.history__rating-ring {
   position: relative;
-  width: 34px;
-  height: 48px;
-  border-radius: 5px;
-  flex-shrink: 0;
-  background: linear-gradient(
-    150deg,
-    var(--color-primary, #4e7b6a),
-    var(--color-primary-dark, #3a5c4f)
-  );
-  box-shadow: 0 3px 8px -4px rgba(0, 0, 0, 0.5);
-}
-
-.history__cover-rating {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
   display: inline-flex;
   align-items: center;
-  gap: 2px;
-  height: 15px;
-  padding: 0 4px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-paper, white) 88%, transparent);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
-  font-size: 9px;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  margin: 0 3px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  vertical-align: middle;
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 4px;
+    border-radius: 50%;
+    background: var(--color-paper, white);
+  }
+}
+
+.history__rating-number {
+  position: relative;
+  z-index: 1;
+  font-size: 12px;
   font-weight: 700;
-  line-height: 1;
-  white-space: nowrap;
 }
 
 .history__body {
@@ -502,10 +503,16 @@ $history-status-color: #8a6fc4;
   white-space: nowrap;
 }
 
-// Фиксированный серый (не --color-text-2, который у части тем имеет
-// цветной оттенок, а не нейтральный серый).
-.history__verb--added {
+// Нейтральные слова-связки («начал», «новую книгу», «со статусом», «книги»,
+// «на») — фиксированный серый, не --color-text-2 (у части тем он с цветным
+// оттенком, не нейтральный).
+.history__filler {
   color: #888;
+  font-weight: 600;
+}
+
+.history__verb--added {
+  color: $history-added-text-color;
   font-weight: 600;
 }
 

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -52,14 +52,38 @@ interface HistoryDayGroup {
   events: HistoryEvent[]
 }
 
-/** Глагол действия для текста события. */
-const HISTORY_VERB: Record<HistoryEventType, string> = {
-  ADDED: 'добавил новую книгу',
-  READING: 'начал читать',
-  DONE: 'прочитал',
-  DROPPED: 'забросил',
-  RATED: 'изменил оценку',
-  STATUS: 'изменил статус книги',
+/** Части фразы-действия — акцентное слово (цвет события) и нейтральные слова-связки (серые). */
+interface HistoryVerbParts {
+  /** Серая часть перед акцентным словом. */
+  prefix?: string
+  /** Акцентное слово/словосочетание — выделяется цветом события. */
+  highlight: string
+  /** Серая часть после акцентного слова. */
+  suffix?: string
+}
+
+/** Глагол действия для текста события, разбитый на акцент и связки. */
+const HISTORY_VERB: Record<HistoryEventType, HistoryVerbParts> = {
+  ADDED: { highlight: 'добавил', suffix: 'новую книгу' },
+  READING: { prefix: 'начал', highlight: 'читать', suffix: 'книгу' },
+  DONE: { highlight: 'прочитал', suffix: 'книгу' },
+  DROPPED: { highlight: 'забросил', suffix: 'книгу' },
+  RATED: { highlight: 'изменил оценку', suffix: 'книги' },
+  STATUS: { highlight: 'изменил статус', suffix: 'книги' },
+}
+
+/** Фраза-действие события — акцентное слово цветом события, связки серым. */
+function VerbPhrase({ type }: { type: HistoryEventType }) {
+  const { prefix, highlight, suffix } = HISTORY_VERB[type]
+  return (
+    <>
+      {prefix && <span className={styles['history__filler']}>{prefix}</span>}
+      {prefix && ' '}
+      <span className={styles[`history__verb--${type.toLowerCase()}`]}>{highlight}</span>
+      {suffix && ' '}
+      {suffix && <span className={styles['history__filler']}>{suffix}</span>}
+    </>
+  )
 }
 
 /** Иконка узла на таймлайне для каждого типа события. */
@@ -89,6 +113,22 @@ function scoreColor(rating: number): string {
 
 /** Цвет звезды идеальной оценки 10/10 — золотой, как в библиотеке. */
 const GOLD_COLOR = '#ffd24a'
+
+/** Кольцо оценки в событии активности — только просмотр, без возможности изменить. */
+function RatingRing({ rating }: { rating: number }) {
+  const color = rating === 10 ? GOLD_COLOR : scoreColor(rating)
+  const pct = rating * 10
+  return (
+    <div
+      className={styles['history__rating-ring']}
+      style={{ background: `conic-gradient(${color} ${pct}%, var(--color-divider, #e0e0e0) 0)` }}
+    >
+      <span className={styles['history__rating-number']} style={{ color }}>
+        {rating}
+      </span>
+    </div>
+  )
+}
 
 /** Пилюля статуса в тексте события — цветной тинт фона, как у статуса на обложке в библиотеке. */
 function StatusChip({ status }: { status: BookStatus }) {
@@ -408,32 +448,15 @@ export const ProfilePage = () => {
                         >
                           <Icon size={14} />
                         </div>
-                        <div className={styles['history__cover']}>
-                          {showsRating && (
-                            <span
-                              className={styles['history__cover-rating']}
-                              style={{ color: rating === 10 ? GOLD_COLOR : scoreColor(rating) }}
-                            >
-                              <Star
-                                size={9}
-                                fill={rating === 10 ? GOLD_COLOR : scoreColor(rating)}
-                                stroke="none"
-                              />
-                              {rating}
-                            </span>
-                          )}
-                        </div>
                         <div className={styles['history__body']}>
                           <p className={styles['history__text']}>
-                            <span className={styles[`history__verb--${event.type.toLowerCase()}`]}>
-                              {HISTORY_VERB[event.type]}
-                            </span>{' '}
+                            <VerbPhrase type={event.type} />{' '}
                             <strong>«{event.entry.book.title}»</strong>
                             {event.type === 'ADDED' &&
                               !hasAccompanyingCreationEvent(event.entry) && (
                                 <>
                                   {' '}
-                                  <span className={styles['history__verb--added']}>
+                                  <span className={styles['history__filler']}>
                                     со статусом
                                   </span>{' '}
                                   <StatusChip status={event.entry.status} />
@@ -442,8 +465,15 @@ export const ProfilePage = () => {
                             {event.type === 'STATUS' && (
                               <>
                                 {' '}
-                                <span className={styles['history__verb--status']}>на</span>{' '}
+                                <span className={styles['history__filler']}>на</span>{' '}
                                 <StatusChip status={event.entry.status} />
+                              </>
+                            )}
+                            {showsRating && rating !== null && (
+                              <>
+                                {' '}
+                                <span className={styles['history__filler']}>на</span>{' '}
+                                <RatingRing rating={rating} />
                               </>
                             )}
                           </p>


### PR DESCRIPTION
## Что сделано
- Убрана декоративная карточка-обложка у событий активности (везде, не только на мобильных)
- Оценка отображается кольцом прогресса инлайн в тексте события («на [кольцо]», тот же паттерн что у пилюли статуса), только просмотр
- Глаголы действий разбиты на акцентное слово (цвет события) и нейтральные слова-связки (серые): «начал читать книгу», «добавил новую книгу», «изменил статус книги», «прочитал книгу», «забросил книгу», «изменил оценку книги» — у «добавил» новый бирюзовый акцентный цвет
- Усилена видимость дата-якорей в активности для светлой темы