### PR TITLE
fix(web): нижнее мобильное меню и панель библиотеки на мобильных

### DIFF
--- a/apps/web/src/pages/library/LibraryPage.module.scss
+++ b/apps/web/src/pages/library/LibraryPage.module.scss
@@ -148,8 +148,6 @@ $breakpoint-small: 600px;
   padding: 0 36px 4px;
 
   @media (max-width: $breakpoint-small) {
-    flex-direction: column;
-    align-items: stretch;
     padding: 0 20px 4px;
   }
 }
@@ -211,7 +209,7 @@ $breakpoint-small: 600px;
   }
 
   @media (max-width: $breakpoint-small) {
-    flex: 0 0 auto;
+    flex: 1;
     min-width: 0;
     max-width: none;
   }

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -118,6 +118,8 @@ export const LibraryPage = () => {
   // На мобильных выбор размера скрыт — всегда крупный (большие шрифты и
   // бейдж оценки), ровно 2 колонки обеспечивает мобильный minmax в SCSS.
   const effectiveCardSize: CardSize = isMobile ? 'large' : cardSize
+  // На мобильных табличный вид недоступен — переключатель скрыт, всегда обложки.
+  const effectiveCardStyle: CardStyle = isMobile ? 'cover' : cardStyle
 
   const isGuest = useAppSelector((s) => s.auth.isGuest)
   const navigate = useNavigate()
@@ -292,7 +294,7 @@ export const LibraryPage = () => {
                 </MenuItem>
               ))}
             </Menu>
-            {!isMobile && cardStyle === 'cover' && (
+            {!isMobile && effectiveCardStyle === 'cover' && (
               <>
                 <button
                   className={styles['library__sort-btn']}
@@ -325,22 +327,24 @@ export const LibraryPage = () => {
                 </Menu>
               </>
             )}
-            <div className={styles['library__style-toggle']}>
-              <button
-                className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
-                onClick={() => setCardStyle('cover')}
-                title="Вид обложками"
-              >
-                <Image size={22} />
-              </button>
-              <button
-                className={`${styles['library__style-btn']} ${cardStyle === 'table' ? styles['library__style-btn--active'] : ''}`}
-                onClick={() => setCardStyle('table')}
-                title="Табличный вид"
-              >
-                <List size={22} />
-              </button>
-            </div>
+            {!isMobile && (
+              <div className={styles['library__style-toggle']}>
+                <button
+                  className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
+                  onClick={() => setCardStyle('cover')}
+                  title="Вид обложками"
+                >
+                  <Image size={22} />
+                </button>
+                <button
+                  className={`${styles['library__style-btn']} ${cardStyle === 'table' ? styles['library__style-btn--active'] : ''}`}
+                  onClick={() => setCardStyle('table')}
+                  title="Табличный вид"
+                >
+                  <List size={22} />
+                </button>
+              </div>
+            )}
           </div>
         </div>
       )}
@@ -388,7 +392,7 @@ export const LibraryPage = () => {
               : 'Нет книг с этим статусом'}
           </p>
         </div>
-      ) : cardStyle === 'table' ? (
+      ) : effectiveCardStyle === 'table' ? (
         <div className={styles['library__table']}>
           <div className={styles['library__table-head']}>
             <span />

--- a/apps/web/src/widgets/layout/AppLayout.module.scss
+++ b/apps/web/src/widgets/layout/AppLayout.module.scss
@@ -1,0 +1,30 @@
+.app-layout {
+  display: flex;
+  min-height: 100vh;
+  background: var(--color-paper-2, #f2f5f1);
+}
+
+.app-layout__drawer {
+  width: var(--sidebar-width);
+  flex-shrink: 0;
+  transition: width 0.2s ease;
+
+  :global(.MuiDrawer-paper) {
+    width: var(--sidebar-width);
+    border: none;
+    overflow-x: hidden;
+    transition: width 0.2s ease;
+  }
+}
+
+.app-layout__main {
+  flex-grow: 1;
+  height: 100vh;
+  overflow: auto;
+  min-width: 0;
+  position: relative;
+
+  &--mobile {
+    padding-bottom: calc(56px + env(safe-area-inset-bottom));
+  }
+}

--- a/apps/web/src/widgets/layout/AppLayout.tsx
+++ b/apps/web/src/widgets/layout/AppLayout.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import type { CSSProperties } from 'react'
 import { Box, Drawer, useMediaQuery, useTheme } from '@mui/material'
 import { Outlet } from 'react-router'
 import { useAppSelector } from '@/shared/lib/store'
@@ -7,6 +8,7 @@ import { ParticleCanvas } from '@/features/animations'
 import { GuestBanner } from '@/features/guest'
 import { Sidebar } from './Sidebar'
 import { MobileNav } from './MobileNav'
+import styles from './AppLayout.module.scss'
 
 export const SIDEBAR_WIDTH = 220
 export const SIDEBAR_COLLAPSED_WIDTH = 64
@@ -29,21 +31,12 @@ export const AppLayout = () => {
   const showParticles = particlesEnabled && !!particleType
 
   return (
-    <Box sx={{ display: 'flex', minHeight: '100vh', bgcolor: 'background.default' }}>
+    <Box className={styles['app-layout']}>
       {!isMobile && (
         <Drawer
           variant="permanent"
-          sx={{
-            width: sidebarWidth,
-            flexShrink: 0,
-            transition: 'width 0.2s ease',
-            '& .MuiDrawer-paper': {
-              width: sidebarWidth,
-              border: 'none',
-              overflowX: 'hidden',
-              transition: 'width 0.2s ease',
-            },
-          }}
+          className={styles['app-layout__drawer']}
+          style={{ '--sidebar-width': `${sidebarWidth}px` } as CSSProperties}
         >
           <Sidebar collapsed={collapsed} onToggle={() => setCollapsed((v) => !v)} />
         </Drawer>
@@ -51,18 +44,7 @@ export const AppLayout = () => {
 
       <Box
         component="main"
-        sx={{
-          flexGrow: 1,
-          // Высота явно зафиксирована, а не растянута через align-items:stretch —
-          // иначе при resize-наблюдении за этим контейнером (ParticleCanvas) высота
-          // могла на долю кадра "поплыть" вслед за высотой контента и застрять
-          // больше реальной, давая лишние скроллы внутри страницы.
-          height: '100vh',
-          overflow: 'auto',
-          minWidth: 0,
-          position: 'relative',
-          pb: isMobile ? '56px' : 0,
-        }}
+        className={`${styles['app-layout__main']} ${isMobile ? styles['app-layout__main--mobile'] : ''}`}
       >
         {showParticles && <ParticleCanvas type={particleType!} />}
         <GuestBanner />

--- a/apps/web/src/widgets/layout/MobileNav.module.scss
+++ b/apps/web/src/widgets/layout/MobileNav.module.scss
@@ -1,0 +1,34 @@
+.mobile-nav {
+  position: fixed;
+  bottom: -5px;
+  left: 0;
+  right: 0;
+  border-top: 1px solid var(--color-divider, #d5e4d8);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+.mobile-nav__items {
+  display: flex;
+  height: 56px;
+  background: var(--color-paper, white);
+}
+
+.mobile-nav__item {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+}
+
+.mobile-nav__icon {
+  font-size: 24px;
+  color: var(--color-text-2, #666);
+  transition: color 0.15s;
+
+  &--active {
+    color: var(--color-primary, #4e7b6a);
+  }
+}

--- a/apps/web/src/widgets/layout/MobileNav.tsx
+++ b/apps/web/src/widgets/layout/MobileNav.tsx
@@ -6,6 +6,7 @@ import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import { useNavigate, useLocation } from 'react-router'
 import type { SvgIconComponent } from '@mui/icons-material'
+import styles from './MobileNav.module.scss'
 
 const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string }[] = [
   { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
@@ -25,17 +26,11 @@ export const MobileNav = () => {
   return (
     <Paper
       elevation={0}
-      sx={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        borderTop: '1px solid',
-        borderColor: 'divider',
-        zIndex: (theme) => theme.zIndex.appBar,
-      }}
+      square
+      className={styles['mobile-nav']}
+      sx={{ zIndex: (theme) => theme.zIndex.appBar }}
     >
-      <Box sx={{ display: 'flex', height: 56, bgcolor: 'background.paper' }}>
+      <Box className={styles['mobile-nav__items']}>
         {NAV_ITEMS.map(({ to, icon: Icon, label }) => {
           // Для "/" нужно точное совпадение, иначе будет активен на всех страницах
           const isActive = to === '/' ? pathname === '/' : pathname.startsWith(to)
@@ -44,22 +39,10 @@ export const MobileNav = () => {
               key={to}
               onClick={() => navigate(to)}
               aria-label={label}
-              sx={{
-                flex: 1,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-                WebkitTapHighlightColor: 'transparent',
-                userSelect: 'none',
-              }}
+              className={styles['mobile-nav__item']}
             >
               <Icon
-                sx={{
-                  fontSize: 24,
-                  color: isActive ? 'primary.main' : 'action.disabled',
-                  transition: 'color 0.15s',
-                }}
+                className={`${styles['mobile-nav__icon']} ${isActive ? styles['mobile-nav__icon--active'] : ''}`}
               />
             </Box>
           )


### PR DESCRIPTION
## Summary
- Нижнее мобильное меню (MobileNav) — убраны скруглённые углы Paper, сдвинуто на -5px вниз с компенсацией через safe-area-inset-bottom, устраняет просвет на некоторых устройствах
- На мобильных убран переключатель вида обложка/таблица (табличный вид недоступен), кнопки фильтра и сортировки перенесены в один ряд с инпутом поиска
- Стили MobileNav и AppLayout перенесены из инлайн sx в .module.scss по БЭМ