### PR TITLE
fix(web): скрыть нерабочие пункты навигации и недоступный функционал

### DIFF
--- a/apps/web/src/pages/home/HomePage.module.scss
+++ b/apps/web/src/pages/home/HomePage.module.scss
@@ -183,6 +183,25 @@ $breakpoint-medium: 900px;
       opacity: 1;
     }
   }
+
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+
+    &:hover {
+      transform: none;
+      box-shadow: none;
+      border-color: var(--color-divider, #e0e0e0);
+
+      &::before {
+        opacity: 0;
+      }
+
+      .grid__tile-icon {
+        transform: none;
+      }
+    }
+  }
 }
 
 .grid__tile-icon {
@@ -435,6 +454,25 @@ $breakpoint-medium: 900px;
 }
 
 // ─── Bento — ячейка импорта и CTA ────────────────────────────────────────────
+
+.bento__cell--disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+
+  &:hover {
+    transform: none;
+    box-shadow: none;
+    border-color: var(--color-divider, #e0e0e0);
+
+    &::before {
+      opacity: 0;
+    }
+
+    .bento__cell-icon {
+      transform: none;
+    }
+  }
+}
 
 .bento__cell--import {
   cursor: not-allowed;

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -11,15 +11,16 @@ import styles from './HomePage.module.scss'
 const TILES = [
   {
     icon: <BookOpen size={22} />,
-    title: 'Найти книгу',
-    desc: 'Добавить в список, отметить прочитанной, поставить оценку.',
+    title: 'Добавить книгу',
+    desc: 'Изменить статус, поставить оценку.',
     href: '/library',
   },
   {
     icon: <Gamepad2 size={22} />,
-    title: 'Найти игру',
-    desc: 'Добавить в список, отметить пройденной, поставить оценку.',
+    title: 'Добавить игру',
+    desc: 'Изменить статус, поставить оценку.',
     href: '/library',
+    disabled: true,
   },
   {
     icon: <User size={22} />,
@@ -30,7 +31,7 @@ const TILES = [
   {
     icon: <Palette size={22} />,
     title: 'Настроить тему',
-    desc: 'Цветовая палитра и шрифт интерфейса.',
+    desc: 'Цветовая палитра и анимации.',
     href: '/settings/appearance',
   },
 ]
@@ -118,7 +119,8 @@ function GridLayout() {
       {TILES.map((tile) => (
         <button
           key={tile.title}
-          className={styles['grid__tile']}
+          className={`${styles['grid__tile']} ${tile.disabled ? styles['grid__tile--disabled'] : ''}`}
+          disabled={tile.disabled}
           onClick={() => navigate(tile.href)}
         >
           <div className={styles['grid__tile-icon']}>{tile.icon}</div>
@@ -126,9 +128,11 @@ function GridLayout() {
             <p className={styles['grid__tile-title']}>{tile.title}</p>
             <p className={styles['grid__tile-desc']}>{tile.desc}</p>
           </div>
-          <span className={styles['grid__tile-arrow']}>
-            <ArrowIcon />
-          </span>
+          {!tile.disabled && (
+            <span className={styles['grid__tile-arrow']}>
+              <ArrowIcon />
+            </span>
+          )}
         </button>
       ))}
     </div>
@@ -159,8 +163,8 @@ function BentoLayout() {
       </button>
 
       <button
-        className={`${styles['bento__cell']} ${styles['bento__cell--dark']}`}
-        onClick={() => navigate(games.href)}
+        className={`${styles['bento__cell']} ${styles['bento__cell--dark']} ${styles['bento__cell--disabled']}`}
+        disabled
       >
         <div className={styles['bento__cell-icon']}>{games.icon}</div>
         <div className={styles['bento__cell-content']}>

--- a/apps/web/src/widgets/layout/MobileNav.module.scss
+++ b/apps/web/src/widgets/layout/MobileNav.module.scss
@@ -21,6 +21,10 @@
   cursor: pointer;
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+
+  &--disabled {
+    cursor: not-allowed;
+  }
 }
 
 .mobile-nav__icon {
@@ -30,5 +34,9 @@
 
   &--active {
     color: var(--color-primary, #4e7b6a);
+  }
+
+  &--disabled {
+    opacity: 0.45;
   }
 }

--- a/apps/web/src/widgets/layout/MobileNav.tsx
+++ b/apps/web/src/widgets/layout/MobileNav.tsx
@@ -8,12 +8,13 @@ import { useNavigate, useLocation } from 'react-router'
 import type { SvgIconComponent } from '@mui/icons-material'
 import styles from './MobileNav.module.scss'
 
-const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string }[] = [
+/** Раздел еще не реализован — пункт виден, но недоступен для перехода. */
+const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string; disabled?: boolean }[] = [
   { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
   { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
   { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
-  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента' },
-  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск' },
+  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента', disabled: true },
+  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск', disabled: true },
 ]
 
 /**
@@ -31,18 +32,19 @@ export const MobileNav = () => {
       sx={{ zIndex: (theme) => theme.zIndex.appBar }}
     >
       <Box className={styles['mobile-nav__items']}>
-        {NAV_ITEMS.map(({ to, icon: Icon, label }) => {
+        {NAV_ITEMS.map(({ to, icon: Icon, label, disabled }) => {
           // Для "/" нужно точное совпадение, иначе будет активен на всех страницах
-          const isActive = to === '/' ? pathname === '/' : pathname.startsWith(to)
+          const isActive = !disabled && (to === '/' ? pathname === '/' : pathname.startsWith(to))
           return (
             <Box
               key={to}
-              onClick={() => navigate(to)}
+              onClick={() => !disabled && navigate(to)}
               aria-label={label}
-              className={styles['mobile-nav__item']}
+              aria-disabled={disabled}
+              className={`${styles['mobile-nav__item']} ${disabled ? styles['mobile-nav__item--disabled'] : ''}`}
             >
               <Icon
-                className={`${styles['mobile-nav__icon']} ${isActive ? styles['mobile-nav__icon--active'] : ''}`}
+                className={`${styles['mobile-nav__icon']} ${isActive ? styles['mobile-nav__icon--active'] : ''} ${disabled ? styles['mobile-nav__icon--disabled'] : ''}`}
               />
             </Box>
           )

--- a/apps/web/src/widgets/layout/Sidebar.module.scss
+++ b/apps/web/src/widgets/layout/Sidebar.module.scss
@@ -122,6 +122,16 @@
   &--collapsed {
     justify-content: center;
   }
+
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.45;
+
+    &:hover {
+      background: transparent;
+      color: var(--sidebar-muted);
+    }
+  }
 }
 
 .nav-item__label {

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -22,15 +22,17 @@ interface NavItemConfig {
   to: string
   icon: SvgIconComponent
   label: string
+  /** Раздел еще не реализован — пункт виден, но недоступен для перехода. */
+  disabled?: boolean
 }
 
 const NAV_ITEMS: NavItemConfig[] = [
   { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
   { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
   { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
-  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента' },
-  { to: '/friends', icon: PeopleOutlinedIcon, label: 'Друзья' },
-  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск' },
+  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента', disabled: true },
+  { to: '/friends', icon: PeopleOutlinedIcon, label: 'Друзья', disabled: true },
+  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск', disabled: true },
 ]
 
 const FOOTER_ITEMS: NavItemConfig[] = [
@@ -41,8 +43,21 @@ interface NavItemProps extends NavItemConfig {
   collapsed: boolean
 }
 
-const NavItem = ({ to, icon: Icon, label, collapsed }: NavItemProps) => {
+const NavItem = ({ to, icon: Icon, label, collapsed, disabled }: NavItemProps) => {
   const isActive = !!useMatch({ path: to, end: to === '/' })
+
+  if (disabled) {
+    return (
+      <Tooltip title="Скоро" placement="right">
+        <span
+          className={`${styles['nav-item']} ${styles['nav-item--disabled']} ${collapsed ? styles['nav-item--collapsed'] : ''}`}
+        >
+          <Icon style={{ fontSize: 22, flexShrink: 0 }} />
+          {!collapsed && <span className={styles['nav-item__label']}>{label}</span>}
+        </span>
+      </Tooltip>
+    )
+  }
 
   return (
     <Link


### PR DESCRIPTION
## Summary
- Sidebar/MobileNav: пункты «Лента», «Друзья», «Поиск» ведут на несуществующие маршруты (роняют react-router в дефолтный error boundary) — сделаны видимыми, но заблокированными (не кликабельны, тултип «Скоро» в Sidebar), не удалены из навигации
- HomePage: «Найти книгу»/«Найти игру» → «Добавить книгу»/«Добавить игру» с подписью «Изменить статус, поставить оценку»; плитка игр помечена disabled; подпись плитки темы поправлена (убрано упоминание несуществующей настройки шрифта)