### PR TITLE
feat(web): лента «в разработке» для disabled-карточек на главной

### DIFF
--- a/apps/web/src/pages/home/HomePage.module.scss
+++ b/apps/web/src/pages/home/HomePage.module.scss
@@ -193,10 +193,6 @@ $breakpoint-medium: 900px;
       box-shadow: none;
       border-color: var(--color-divider, #e0e0e0);
 
-      &::before {
-        opacity: 0;
-      }
-
       .grid__tile-icon {
         transform: none;
       }
@@ -463,10 +459,6 @@ $breakpoint-medium: 900px;
     transform: none;
     box-shadow: none;
     border-color: var(--color-divider, #e0e0e0);
-
-    &::before {
-      opacity: 0;
-    }
 
     .bento__cell-icon {
       transform: none;

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -1,7 +1,9 @@
+import { Fragment } from 'react'
 import { BookOpen, Gamepad2, LayoutGrid, Palette, PanelTop, User } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import { setLayout } from '@/features/layout'
+import { UnderConstruction } from '@/shared/ui'
 import type { LayoutVariant } from '@/shared/config/layout'
 import styles from './HomePage.module.scss'
 
@@ -116,25 +118,32 @@ function GridLayout() {
 
   return (
     <div className={styles['grid']}>
-      {TILES.map((tile) => (
-        <button
-          key={tile.title}
-          className={`${styles['grid__tile']} ${tile.disabled ? styles['grid__tile--disabled'] : ''}`}
-          disabled={tile.disabled}
-          onClick={() => navigate(tile.href)}
-        >
-          <div className={styles['grid__tile-icon']}>{tile.icon}</div>
-          <div>
-            <p className={styles['grid__tile-title']}>{tile.title}</p>
-            <p className={styles['grid__tile-desc']}>{tile.desc}</p>
-          </div>
-          {!tile.disabled && (
-            <span className={styles['grid__tile-arrow']}>
-              <ArrowIcon />
-            </span>
-          )}
-        </button>
-      ))}
+      {TILES.map((tile) => {
+        const button = (
+          <button
+            className={`${styles['grid__tile']} ${tile.disabled ? styles['grid__tile--disabled'] : ''}`}
+            disabled={tile.disabled}
+            onClick={() => navigate(tile.href)}
+          >
+            <div className={styles['grid__tile-icon']}>{tile.icon}</div>
+            <div>
+              <p className={styles['grid__tile-title']}>{tile.title}</p>
+              <p className={styles['grid__tile-desc']}>{tile.desc}</p>
+            </div>
+            {!tile.disabled && (
+              <span className={styles['grid__tile-arrow']}>
+                <ArrowIcon />
+              </span>
+            )}
+          </button>
+        )
+
+        return tile.disabled ? (
+          <UnderConstruction key={tile.title}>{button}</UnderConstruction>
+        ) : (
+          <Fragment key={tile.title}>{button}</Fragment>
+        )
+      })}
     </div>
   )
 }
@@ -162,16 +171,18 @@ function BentoLayout() {
         </div>
       </button>
 
-      <button
-        className={`${styles['bento__cell']} ${styles['bento__cell--dark']} ${styles['bento__cell--disabled']}`}
-        disabled
-      >
-        <div className={styles['bento__cell-icon']}>{games.icon}</div>
-        <div className={styles['bento__cell-content']}>
-          <p className={styles['bento__cell-title']}>{games.title}</p>
-          <p className={styles['bento__cell-desc']}>{games.desc}</p>
-        </div>
-      </button>
+      <UnderConstruction>
+        <button
+          className={`${styles['bento__cell']} ${styles['bento__cell--dark']} ${styles['bento__cell--disabled']}`}
+          disabled
+        >
+          <div className={styles['bento__cell-icon']}>{games.icon}</div>
+          <div className={styles['bento__cell-content']}>
+            <p className={styles['bento__cell-title']}>{games.title}</p>
+            <p className={styles['bento__cell-desc']}>{games.desc}</p>
+          </div>
+        </button>
+      </UnderConstruction>
 
       <button className={styles['bento__cell']} onClick={() => navigate(profile.href)}>
         <div className={styles['bento__cell-icon']}>{profile.icon}</div>
@@ -190,21 +201,23 @@ function BentoLayout() {
       </button>
 
       {/* Импорт как пятая ячейка bento */}
-      <button className={`${styles['bento__cell']} ${styles['bento__cell--import']}`} disabled>
-        <div className={styles['bento__cell-icon']}>
-          <BookOpen size={22} />
-        </div>
-        <div className={styles['bento__cell-content']}>
-          <p className={styles['bento__cell-title']}>Импорт</p>
-          <p className={styles['bento__cell-desc']}>Goodreads, HLTB — скоро</p>
-        </div>
-        <span className={styles['bento__cell-cta']}>
-          <span className={styles['bento__cell-cta-text']}>Подключить</span>
-          <span className={styles['bento__cell-cta-arrow']}>
-            <ArrowIcon />
+      <UnderConstruction>
+        <button className={`${styles['bento__cell']} ${styles['bento__cell--import']}`} disabled>
+          <div className={styles['bento__cell-icon']}>
+            <BookOpen size={22} />
+          </div>
+          <div className={styles['bento__cell-content']}>
+            <p className={styles['bento__cell-title']}>Импорт</p>
+            <p className={styles['bento__cell-desc']}>Goodreads, HLTB — скоро</p>
+          </div>
+          <span className={styles['bento__cell-cta']}>
+            <span className={styles['bento__cell-cta-text']}>Подключить</span>
+            <span className={styles['bento__cell-cta-arrow']}>
+              <ArrowIcon />
+            </span>
           </span>
-        </span>
-      </button>
+        </button>
+      </UnderConstruction>
     </div>
   )
 }
@@ -214,22 +227,24 @@ function BentoLayout() {
  */
 function ImportStrip() {
   return (
-    <div className={styles['import-strip']}>
-      <div className={styles['import-strip__left']}>
-        <div className={styles['import-strip__icon']}>
-          <BookOpen size={18} />
+    <UnderConstruction>
+      <div className={styles['import-strip']}>
+        <div className={styles['import-strip__left']}>
+          <div className={styles['import-strip__icon']}>
+            <BookOpen size={18} />
+          </div>
+          <div>
+            <p className={styles['import-strip__title']}>Импортировать списки</p>
+            <p className={styles['import-strip__sub']}>Goodreads, HLTB — скоро</p>
+          </div>
         </div>
-        <div>
-          <p className={styles['import-strip__title']}>Импортировать списки</p>
-          <p className={styles['import-strip__sub']}>Goodreads, HLTB — скоро</p>
-        </div>
+        <button className={styles['import-strip__btn']} disabled>
+          <span className={styles['import-strip__btn-text']}>Подключить</span>
+          <span className={styles['import-strip__btn-arrow']}>
+            <ArrowIcon />
+          </span>
+        </button>
       </div>
-      <button className={styles['import-strip__btn']} disabled>
-        <span className={styles['import-strip__btn-text']}>Подключить</span>
-        <span className={styles['import-strip__btn-arrow']}>
-          <ArrowIcon />
-        </span>
-      </button>
-    </div>
+    </UnderConstruction>
   )
 }

--- a/apps/web/src/shared/ui/UnderConstruction/UnderConstruction.module.scss
+++ b/apps/web/src/shared/ui/UnderConstruction/UnderConstruction.module.scss
@@ -1,0 +1,27 @@
+.under-construction {
+  // Затемняет карточку целиком, включая её собственный фон (а не только
+  // дочерние элементы) - плоская полупрозрачная серая плёнка
+  &__veil {
+    position: absolute;
+    inset: 0;
+    background: rgba(128, 128, 128, 0.45);
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  // Лента ограждения в верхнем правом углу. Размеры в % (от ширины
+  // элемента) и em (от его font-size) - масштабируются вместе с размером
+  // самого элемента без дополнительных пропсов.
+  &__ribbon {
+    position: absolute;
+    top: 0.5em;
+    right: -18%;
+    width: 70%;
+    height: 1.4em;
+    background: repeating-linear-gradient(45deg, #f0b429 0 0.5em, #2b2b2b 0.5em 1em);
+    transform: rotate(45deg);
+    box-shadow: 0 0.07em 0.3em rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    z-index: 2;
+  }
+}

--- a/apps/web/src/shared/ui/UnderConstruction/UnderConstruction.tsx
+++ b/apps/web/src/shared/ui/UnderConstruction/UnderConstruction.tsx
@@ -1,0 +1,39 @@
+import { Children, cloneElement } from 'react'
+import type { ReactElement, ReactNode } from 'react'
+import styles from './UnderConstruction.module.scss'
+
+/**
+ * Свойства UnderConstruction.
+ */
+interface Props {
+  /** Единственный оборачиваемый элемент - кнопка, карточка и т.д.
+   *  Должен иметь position: relative (и желательно overflow: hidden),
+   *  чтобы лента корректно располагалась и клипалась по краю. */
+  children: ReactElement<{ className?: string; children?: ReactNode }>
+}
+
+/**
+ * Помечает обёрнутый элемент как недоступный функционал "в разработке" -
+ * добавляет ленту ограждения и затемняет (обесцвечивает) карточку целиком,
+ * включая её фон. Класс навешивается прямо на переданный элемент (через
+ * cloneElement), без обёртки в DOM, поэтому не влияет на layout родителя
+ * (grid/flex). Вуаль и лента — настоящие дочерние элементы, а не
+ * ::before/::after, чтобы не конфликтовать с собственными псевдоэлементами
+ * оборачиваемой карточки (анимации, hover-эффекты и т.д.). Размеры ленты
+ * заданы в % и em, поэтому масштабируются вместе с размером самого элемента.
+ */
+export const UnderConstruction = ({ children }: Props) => {
+  const child = Children.only(children)
+
+  return cloneElement(
+    child,
+    {
+      className: `${child.props.className ?? ''} ${styles['under-construction']}`.trim(),
+    },
+    <>
+      {child.props.children}
+      <span className={styles['under-construction__veil']} aria-hidden="true" />
+      <span className={styles['under-construction__ribbon']} aria-hidden="true" />
+    </>,
+  )
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -1,0 +1,1 @@
+export { UnderConstruction } from './UnderConstruction/UnderConstruction'


### PR DESCRIPTION
## Summary
- Новый переиспользуемый компонент `shared/ui/UnderConstruction` — навешивает на любой элемент ленту ограждения в углу + затемнение фона целиком (вуаль), обозначая недоступный пока функционал
- Реализован через `cloneElement` без обёртки в DOM (не влияет на layout родителя grid/flex); вуаль и лента — настоящие дочерние span, не `::before`/`::after`, поэтому не конфликтуют с собственными псевдоэлементами/анимациями оборачиваемой карточки
- Размеры ленты в %/em — масштабируются вместе с размером самого элемента
- Применён к плитке «Добавить игру» и карточке «Импортировать списки» на главной странице (оба вида — Grid и Bento)