### PR TITLE
feat(web): заменить нативные title-тултипы на MUI Tooltip

### DIFF
--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import type { MouseEvent } from 'react'
-import { Box, Menu, MenuItem, Popover, Rating, Slider, Typography } from '@mui/material'
+import { Box, Menu, MenuItem, Popover, Rating, Slider, Tooltip, Typography } from '@mui/material'
 import { Check, Star } from 'lucide-react'
 import { STATUS_LABEL } from '../../model/book.types'
 import type { BookEntry, BookStatus } from '../../model/book.types'
@@ -72,34 +72,36 @@ function ScoreBadge({
   const color = scoreColor(rating)
 
   return (
-    <div className={styles['cover-card__score']} onClick={onClick} title={`Оценка ${rating}/10`}>
-      <svg className={styles['cover-card__score-ring']} viewBox="0 0 34 34">
-        <circle
-          cx="17"
-          cy="17"
-          r={radius}
-          fill="none"
-          stroke="rgba(255,255,255,0.18)"
-          strokeWidth="3"
-        />
-        <circle
-          cx="17"
-          cy="17"
-          r={radius}
-          fill="none"
-          stroke={color}
-          strokeWidth="3"
-          strokeLinecap="round"
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-        />
-      </svg>
-      {rating === 10 ? (
-        <Star size={14} fill="#fff" stroke="none" />
-      ) : (
-        <span className={styles['cover-card__score-value']}>{rating}</span>
-      )}
-    </div>
+    <Tooltip title={`Оценка ${rating}/10`}>
+      <div className={styles['cover-card__score']} onClick={onClick}>
+        <svg className={styles['cover-card__score-ring']} viewBox="0 0 34 34">
+          <circle
+            cx="17"
+            cy="17"
+            r={radius}
+            fill="none"
+            stroke="rgba(255,255,255,0.18)"
+            strokeWidth="3"
+          />
+          <circle
+            cx="17"
+            cy="17"
+            r={radius}
+            fill="none"
+            stroke={color}
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={offset}
+          />
+        </svg>
+        {rating === 10 ? (
+          <Star size={14} fill="#fff" stroke="none" />
+        ) : (
+          <span className={styles['cover-card__score-value']}>{rating}</span>
+        )}
+      </div>
+    </Tooltip>
   )
 }
 

--- a/apps/web/src/pages/home/HomePage.tsx
+++ b/apps/web/src/pages/home/HomePage.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from 'react'
+import { Tooltip } from '@mui/material'
 import { BookOpen, Gamepad2, LayoutGrid, Palette, PanelTop, User } from 'lucide-react'
 import { useNavigate } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
@@ -80,20 +81,22 @@ export function HomePage() {
 
         {/* Переключатель вида */}
         <div className={styles['home__layout-toggle']}>
-          <button
-            className={`${styles['home__layout-btn']} ${layout === 'grid' ? styles['home__layout-btn--active'] : ''}`}
-            onClick={() => handleLayoutChange('grid')}
-            title="Сетка"
-          >
-            <LayoutGrid size={16} />
-          </button>
-          <button
-            className={`${styles['home__layout-btn']} ${layout === 'bento' ? styles['home__layout-btn--active'] : ''}`}
-            onClick={() => handleLayoutChange('bento')}
-            title="Bento"
-          >
-            <PanelTop size={16} />
-          </button>
+          <Tooltip title="Сетка">
+            <button
+              className={`${styles['home__layout-btn']} ${layout === 'grid' ? styles['home__layout-btn--active'] : ''}`}
+              onClick={() => handleLayoutChange('grid')}
+            >
+              <LayoutGrid size={16} />
+            </button>
+          </Tooltip>
+          <Tooltip title="Bento">
+            <button
+              className={`${styles['home__layout-btn']} ${layout === 'bento' ? styles['home__layout-btn--active'] : ''}`}
+              onClick={() => handleLayoutChange('bento')}
+            >
+              <PanelTop size={16} />
+            </button>
+          </Tooltip>
         </div>
       </div>
 

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -23,6 +23,7 @@ import {
   Box,
   Menu,
   MenuItem,
+  Tooltip,
   useMediaQuery,
   useTheme,
 } from '@mui/material'
@@ -217,25 +218,27 @@ export const LibraryPage = () => {
               onChange={(e) => setSearchQuery(e.target.value)}
             />
             {searchQuery && (
-              <button
-                className={styles['library__search-clear']}
-                onClick={() => setSearchQuery('')}
-                title="Очистить"
-              >
-                <X size={14} />
-              </button>
+              <Tooltip title="Очистить">
+                <button
+                  className={styles['library__search-clear']}
+                  onClick={() => setSearchQuery('')}
+                >
+                  <X size={14} />
+                </button>
+              </Tooltip>
             )}
           </div>
           <div className={styles['library__label-row-actions']}>
             {isMobile && (
               <>
-                <button
-                  className={`${styles['library__filter-btn']} ${statusFilter !== 'ALL' ? styles['library__filter-btn--active'] : ''}`}
-                  onClick={(e) => setFilterAnchor(e.currentTarget)}
-                  title="Фильтр по статусу"
-                >
-                  <Filter size={15} />
-                </button>
+                <Tooltip title="Фильтр по статусу">
+                  <button
+                    className={`${styles['library__filter-btn']} ${statusFilter !== 'ALL' ? styles['library__filter-btn--active'] : ''}`}
+                    onClick={(e) => setFilterAnchor(e.currentTarget)}
+                  >
+                    <Filter size={15} />
+                  </button>
+                </Tooltip>
                 <Menu
                   anchorEl={filterAnchor}
                   open={!!filterAnchor}
@@ -296,14 +299,15 @@ export const LibraryPage = () => {
             </Menu>
             {!isMobile && effectiveCardStyle === 'cover' && (
               <>
-                <button
-                  className={styles['library__sort-btn']}
-                  onClick={(e) => setSizeAnchor(e.currentTarget)}
-                  title="Размер карточек"
-                >
-                  <SlidersHorizontal size={15} />
-                  {CARD_SIZE_OPTIONS.find((o) => o.value === cardSize)?.label}
-                </button>
+                <Tooltip title="Размер карточек">
+                  <button
+                    className={styles['library__sort-btn']}
+                    onClick={(e) => setSizeAnchor(e.currentTarget)}
+                  >
+                    <SlidersHorizontal size={15} />
+                    {CARD_SIZE_OPTIONS.find((o) => o.value === cardSize)?.label}
+                  </button>
+                </Tooltip>
                 <Menu
                   anchorEl={sizeAnchor}
                   open={!!sizeAnchor}
@@ -329,20 +333,22 @@ export const LibraryPage = () => {
             )}
             {!isMobile && (
               <div className={styles['library__style-toggle']}>
-                <button
-                  className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
-                  onClick={() => setCardStyle('cover')}
-                  title="Вид обложками"
-                >
-                  <Image size={22} />
-                </button>
-                <button
-                  className={`${styles['library__style-btn']} ${cardStyle === 'table' ? styles['library__style-btn--active'] : ''}`}
-                  onClick={() => setCardStyle('table')}
-                  title="Табличный вид"
-                >
-                  <List size={22} />
-                </button>
+                <Tooltip title="Вид обложками">
+                  <button
+                    className={`${styles['library__style-btn']} ${cardStyle === 'cover' ? styles['library__style-btn--active'] : ''}`}
+                    onClick={() => setCardStyle('cover')}
+                  >
+                    <Image size={22} />
+                  </button>
+                </Tooltip>
+                <Tooltip title="Табличный вид">
+                  <button
+                    className={`${styles['library__style-btn']} ${cardStyle === 'table' ? styles['library__style-btn--active'] : ''}`}
+                    onClick={() => setCardStyle('table')}
+                  >
+                    <List size={22} />
+                  </button>
+                </Tooltip>
               </div>
             )}
           </div>
@@ -375,10 +381,14 @@ export const LibraryPage = () => {
               <Plus size={17} />
               Добавить книгу
             </button>
-            <button className={styles['library__cta-ghost']} disabled title="Скоро">
-              <Upload size={16} />
-              Импортировать список
-            </button>
+            <Tooltip title="Скоро">
+              <span>
+                <button className={styles['library__cta-ghost']} disabled>
+                  <Upload size={16} />
+                  Импортировать список
+                </button>
+              </span>
+            </Tooltip>
           </div>
         </div>
       ) : isFilteredEmpty ? (

--- a/apps/web/src/pages/profile/ProfilePage.tsx
+++ b/apps/web/src/pages/profile/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
+import { Tooltip } from '@mui/material'
 import {
   ArrowRight,
   BarChart3,
@@ -386,14 +387,17 @@ export const ProfilePage = () => {
             </div>
             {user?.bio && <p className={styles['header__bio']}>{user.bio}</p>}
           </div>
-          <button
-            className={styles['header__auth-btn']}
-            onClick={isGuest ? () => navigate('/login') : handleLogout}
-            title={isGuest ? 'Войти' : 'Выйти'}
-          >
-            {isGuest ? <LogIn size={15} /> : <LogOut size={15} />}
-            <span className={styles['header__auth-btn-label']}>{isGuest ? 'Войти' : 'Выйти'}</span>
-          </button>
+          <Tooltip title={isGuest ? 'Войти' : 'Выйти'}>
+            <button
+              className={styles['header__auth-btn']}
+              onClick={isGuest ? () => navigate('/login') : handleLogout}
+            >
+              {isGuest ? <LogIn size={15} /> : <LogOut size={15} />}
+              <span className={styles['header__auth-btn-label']}>
+                {isGuest ? 'Войти' : 'Выйти'}
+              </span>
+            </button>
+          </Tooltip>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- HomePage (переключатель вида), ProfilePage (Войти/Выйти), LibraryPage (Очистить, фильтр по статусу, размер карточек, вид обложками/таблицей, импорт списка), BookCoverCard (бейдж оценки) — нативный атрибут `title` заменён на `MuiTooltip`, как уже было в Sidebar
- Disabled-кнопка импорта обёрнута в `<span>` — MUI Tooltip не получает события мыши на `disabled`-элементах