### PR TITLE
feat(web): добавить Dockerfile для продакшна и VITE_API_URL вместо хардкода

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,33 @@
+# ── Стадия 1: builder ────────────────────────────────────────────────────────
+# Устанавливаем зависимости и собираем статический бандл.
+FROM node:24-alpine AS builder
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+COPY apps/web/package.json ./apps/web/
+RUN npm install
+
+COPY tsconfig.json ./
+COPY apps/web/ ./apps/web/
+
+# Vite инлайнит VITE_*-переменные в бандл на этапе сборки, а не читает их
+# в браузере в runtime — поэтому адрес api нужно передать именно как
+# build-time аргумент, а не просто переменную окружения контейнера.
+ARG VITE_API_URL
+ENV VITE_API_URL=$VITE_API_URL
+
+RUN npm run build --workspace=@treqio/web
+
+
+# ── Стадия 2: runner ─────────────────────────────────────────────────────────
+# Статическая раздача собранного SPA через serve. Флаг -s включает fallback
+# на index.html для любых не найденных путей — без этого прямой переход
+# по ссылке на /library или /profile (роуты react-router) даст 404.
+FROM node:24-alpine AS runner
+WORKDIR /app
+
+COPY --from=builder /app/apps/web/dist ./dist
+RUN npm install -g serve
+
+EXPOSE 3000
+CMD ["sh", "-c", "serve -s dist -l ${PORT:-3000}"]

--- a/apps/web/src/shared/api/baseApi.ts
+++ b/apps/web/src/shared/api/baseApi.ts
@@ -3,9 +3,14 @@ import type { BaseQueryFn, FetchArgs, FetchBaseQueryError } from '@reduxjs/toolk
 import { logout, setCredentials } from '@/features/auth'
 import type { RootState } from '@/app/store'
 
+// В проде web и api на разных доменах — адрес api приходит из переменной
+// окружения, инлайнится в бандл на этапе сборки. Локально переменная не
+// задана, и запросы идут через прокси Vite на относительный путь /api.
+const API_URL = (import.meta.env['VITE_API_URL'] as string | undefined) ?? '/api'
+
 /** Базовый fetch с токеном из store и автоматической отправкой cookie. */
 const baseQuery = fetchBaseQuery({
-  baseUrl: '/api',
+  baseUrl: API_URL,
   credentials: 'include', // отправляет httpOnly cookie с refresh token автоматически
   prepareHeaders: (headers, { getState }) => {
     const token = (getState() as RootState).auth.accessToken


### PR DESCRIPTION
Closes #157

## Что сделано
- `apps/web/src/shared/api/baseApi.ts`: вместо хардкода `baseUrl: '/api'` теперь читаем `VITE_API_URL` (по аналогии с `LoginPage.tsx`), с фолбэком на `/api` для локальной разработки через прокси Vite.
- Новый `apps/web/Dockerfile`: двухстадийная сборка — Vite build в builder-стадии, статическая раздача через `serve -s dist` в runner-стадии. Флаг `-s` включает SPA-fallback на `index.html`, иначе прямой переход по `/library`, `/profile` и т.д. дал бы 404. `serve -l ${PORT}` учитывает динамический порт от Railway.
- `VITE_API_URL` передаётся как build-time `ARG`/`ENV`, так как Vite инлайнит `VITE_`-переменные в бандл на этапе сборки, а не читает их в браузере.

## Как проверено
Собрал образ локально через `docker build --build-arg VITE_API_URL=...`, проверил что значение реально попало в собранный JS-бандл. Запустил контейнер и проверил: `/` отдаёт 200, несуществующий путь `/library` (клиентский роут react-router) тоже отдаёт 200 с тем же `index.html` — fallback работает. Также прогнаны `typecheck`, `lint`, `test` для `@treqio/web`.