### PR TITLE
fix(api): отключить сетевую телеметрию npm при сборке docker-образа

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -5,6 +5,12 @@
 FROM node:24-alpine AS builder
 WORKDIR /app
 
+# Некоторые пакеты при установке стучатся на сервера телеметрии без таймаута
+# (проверка обновлений Prisma, аналитика @scarf/scarf) — в облачной среде
+# сборки Railway такие соединения зависают, а не падают с ошибкой.
+ENV CHECKPOINT_DISABLE=1
+ENV DO_NOT_TRACK=1
+
 COPY package.json package-lock.json ./
 COPY apps/api/package.json ./apps/api/
 RUN npm install
@@ -23,6 +29,8 @@ RUN npm run build --workspace=@treqio/api
 FROM node:24-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+ENV CHECKPOINT_DISABLE=1
+ENV DO_NOT_TRACK=1
 
 COPY --from=builder /app/apps/api/dist ./dist
 COPY --from=builder /app/apps/api/package.json ./package.json


### PR DESCRIPTION
Closes #159

## Что сделано
При первом деплое `api` на Railway сборка зависала на шаге `npm install` (10+ минут без завершения), хотя локально та же команда занимает секунды. Вероятная причина — сетевые запросы телеметрии без таймаута у некоторых пакетов (проверка обновлений Prisma, аналитика `@scarf/scarf`), которые в облачной среде сборки не проходят и зависают вместо падения с ошибкой.

Добавлены `ENV CHECKPOINT_DISABLE=1` и `ENV DO_NOT_TRACK=1` перед обоими шагами `npm install` (builder и runner) в `apps/api/Dockerfile`.

## Как проверено
Пересобрал образ локально (`docker build --no-cache`) — собирается без изменений по времени, ошибок нет.