### PR TITLE
fix(web): восстановление сессии и профиля через VITE_API_URL вместо хардкода

### DIFF
--- a/apps/web/src/app/providers/AuthProvider.tsx
+++ b/apps/web/src/app/providers/AuthProvider.tsx
@@ -2,6 +2,11 @@ import { useEffect } from 'react'
 import { useAppDispatch } from '@/shared/lib/store'
 import { setCredentials, setInitialized } from '@/features/auth'
 
+// В проде web и api на разных доменах — адрес api приходит из переменной
+// окружения, инлайнится в бандл на этапе сборки. Локально переменная не
+// задана, и запрос идёт через прокси Vite на относительный путь /api.
+const API_URL = (import.meta.env['VITE_API_URL'] as string | undefined) ?? '/api'
+
 /**
  * Пропсы провайдера авторизации.
  */
@@ -21,7 +26,7 @@ export function AuthProvider({ children }: Props) {
   useEffect(() => {
     const restoreSession = async () => {
       try {
-        const res = await fetch('/api/auth/refresh', {
+        const res = await fetch(`${API_URL}/auth/refresh`, {
           method: 'POST',
           credentials: 'include',
         })

--- a/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/auth-callback/AuthCallbackPage.tsx
@@ -6,6 +6,11 @@ import { setCredentials, setUser } from '@/features/auth'
 import { consumeRedirectPath } from '@/shared/lib/redirectPath'
 import { useAppDispatch } from '@/shared/lib/store'
 
+// В проде web и api на разных доменах — адрес api приходит из переменной
+// окружения, инлайнится в бандл на этапе сборки. Локально переменная не
+// задана, и запрос идёт через прокси Vite на относительный путь /api.
+const API_URL = (import.meta.env['VITE_API_URL'] as string | undefined) ?? '/api'
+
 /**
  * Обработчик редиректа после OAuth авторизации.
  */
@@ -27,7 +32,7 @@ export function AuthCallbackPage() {
       try {
         dispatch(setCredentials({ accessToken }))
 
-        const res = await fetch('/api/auth/me', {
+        const res = await fetch(`${API_URL}/auth/me`, {
           headers: { Authorization: `Bearer ${accessToken}` },
           credentials: 'include',
         })


### PR DESCRIPTION
Closes #161

## Что сделано
После логина через Google всё работало, но обновление страницы выкидывало на логин снова.

Причина: `AuthProvider.tsx` (восстановление сессии по refresh-cookie) и `AuthCallbackPage.tsx` (загрузка профиля сразу после OAuth-редиректа) использовали хардкодный относительный путь `/api/...` — он резолвится в адрес самого web-сервиса, а не api. Локально работало только благодаря прокси Vite; в продакшне (web и api на разных доменах) запрос уходил в статический сервер `serve`, который на любой неизвестный путь отдаёт SPA-fallback (`index.html`), и попытка распарсить его как JSON тихо проваливалась.

Тот же паттерн (`VITE_API_URL` с фолбэком на `/api`) уже использовался в `baseApi.ts` и `LoginPage.tsx` — теперь применён везде.

## Как проверено
Прогнаны `typecheck` и `lint` для `@treqio/web`. Полноценно проверить на проде можно будет после релиза в `main`.