### PR TITLE
fix(ci): trigger workflow on PRs to main instead of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: CI
 
-# Запускаем на каждый PR в develop (защита перед мерджем) и на каждый push
-# в main (чтобы у Railway было что ждать через переключатель "Wait for CI").
+# Запускаем на каждый PR в main (защита перед мерджем) и на каждый push
+# в main (чтобы у Railway было что ждать через переключатель "Wait for CI" —
+# squash-коммит мерджа получает новый SHA, отдельный от проверок самого PR).
 on:
   pull_request:
-    branches: [develop]
+    branches: [main]
   push:
     branches: [main]
 


### PR DESCRIPTION
Closes #166

## Changes
After migrating to GitHub Flow (`develop` branch deleted, renamed to `main` — see #154), the `pull_request` trigger in `ci.yml` still referenced the now-nonexistent `develop` branch. Changed to `branches: [main]`.