### PR TITLE
fix(web): hide rating unless status is done and fix popover position

### DIFF
--- a/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCard/BookCoverCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { forwardRef, useState } from 'react'
 import type { MouseEvent } from 'react'
 import { Box, Menu, MenuItem, Popover, Rating, Slider, Tooltip, Typography } from '@mui/material'
 import { Check, Star } from 'lucide-react'
@@ -47,16 +47,16 @@ function scoreColor(rating: number): string {
 /**
  * Круглый бейдж с оценкой (или плейсхолдер если книга не оценена).
  */
-function ScoreBadge({
-  rating,
-  onClick,
-}: {
-  rating: number | null
-  onClick: (e: MouseEvent<HTMLElement>) => void
-}) {
+const ScoreBadge = forwardRef<
+  HTMLDivElement,
+  {
+    rating: number | null
+    onClick: (e: MouseEvent<HTMLElement>) => void
+  }
+>(function ScoreBadge({ rating, onClick }, ref) {
   if (rating === null) {
     return (
-      <div className={styles['cover-card__score']} onClick={onClick}>
+      <div ref={ref} className={styles['cover-card__score']} onClick={onClick}>
         <span
           className={`${styles['cover-card__score-value']} ${styles['cover-card__score-value--empty']}`}
         >
@@ -73,7 +73,7 @@ function ScoreBadge({
 
   return (
     <Tooltip title={`Оценка ${rating}/10`}>
-      <div className={styles['cover-card__score']} onClick={onClick}>
+      <div ref={ref} className={styles['cover-card__score']} onClick={onClick}>
         <svg className={styles['cover-card__score-ring']} viewBox="0 0 34 34">
           <circle
             cx="17"
@@ -103,7 +103,7 @@ function ScoreBadge({
       </div>
     </Tooltip>
   )
-}
+})
 
 /** Размер карточки — масштабирует шрифты и бейдж оценки внутри обложки. */
 type CardSize = 'compact' | 'medium' | 'large'
@@ -140,8 +140,16 @@ export const BookCoverCard = ({
   onRatingChange,
 }: BookCoverCardProps) => {
   const { book, status, rating, progress } = entry
-  const [statusAnchor, setStatusAnchor] = useState<HTMLElement | null>(null)
-  const [ratingAnchor, setRatingAnchor] = useState<HTMLElement | null>(null)
+  // anchorEl держим в state, обновляемом через callback ref, а не как
+  // ссылку, замороженную в момент клика: если фоновая перезагрузка списка
+  // (после мутации статуса/оценки) пересоздаст DOM-узел карточки, пока
+  // поп-овер ещё открыт, React сам вызовет callback ref на новом узле —
+  // и anchorEl останется верным. Замороженная на клике ссылка вместо этого
+  // указывала бы в никуда, и MUI Popover схлопывал позицию в (0,0).
+  const [statusEl, setStatusEl] = useState<HTMLSpanElement | null>(null)
+  const [scoreEl, setScoreEl] = useState<HTMLDivElement | null>(null)
+  const [statusOpen, setStatusOpen] = useState(false)
+  const [ratingOpen, setRatingOpen] = useState(false)
   // Черновое значение слайдера — обновляется при перетаскивании,
   // а мутация отправляется только когда пользователь отпускает слайдер.
   const [ratingDraft, setRatingDraft] = useState(rating ?? 5)
@@ -154,33 +162,36 @@ export const BookCoverCard = ({
   /** Открывает поп-овер выбора статуса, не давая клику дойти до редактирования всей карточки. */
   const handleStatusClick = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation()
-    setStatusAnchor(e.currentTarget)
+    setStatusOpen(true)
   }
 
   /** Открывает поп-овер выбора оценки, не давая клику дойти до редактирования всей карточки. */
   const handleRatingClick = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation()
     setRatingDraft(rating ?? 5)
-    setRatingAnchor(e.currentTarget)
+    setRatingOpen(true)
   }
 
   return (
     <div className={`${styles['cover-card']} ${styles[`cover-card--${size}`] ?? ''}`}>
       <div className={styles['cover-card__cover-frame']}>
         <div className={styles['cover-card__cover']} onClick={onEdit}>
-          <ScoreBadge rating={rating} onClick={handleRatingClick} />
+          {status === 'DONE' && (
+            <ScoreBadge ref={setScoreEl} rating={rating} onClick={handleRatingClick} />
+          )}
           <div className={styles['cover-card__title']}>
             <span className={styles['cover-card__title-text']}>{book.title}</span>
           </div>
           <div className={styles['cover-card__author']}>{book.author}</div>
         </div>
-        {rating === 10 && <div className={styles['cover-card__gold-ring']} />}
+        {status === 'DONE' && rating === 10 && <div className={styles['cover-card__gold-ring']} />}
       </div>
 
       {(showStatus || progressPct !== null) && (
         <div className={styles['cover-card__footer']}>
           {showStatus && (
             <span
+              ref={setStatusEl}
               className={`${styles['cover-card__status']} ${STATUS_CLASS[status]}`}
               onClick={handleStatusClick}
             >
@@ -200,9 +211,9 @@ export const BookCoverCard = ({
       )}
 
       <Menu
-        anchorEl={statusAnchor}
-        open={!!statusAnchor}
-        onClose={() => setStatusAnchor(null)}
+        anchorEl={statusEl}
+        open={statusOpen}
+        onClose={() => setStatusOpen(false)}
         slotProps={{ list: { dense: true } }}
       >
         {STATUS_OPTIONS.map((option) => (
@@ -213,7 +224,7 @@ export const BookCoverCard = ({
             onClick={(e) => {
               e.stopPropagation()
               onStatusChange?.(option.value)
-              setStatusAnchor(null)
+              setStatusOpen(false)
             }}
           >
             <Box
@@ -232,9 +243,9 @@ export const BookCoverCard = ({
       </Menu>
 
       <Popover
-        anchorEl={ratingAnchor}
-        open={!!ratingAnchor}
-        onClose={() => setRatingAnchor(null)}
+        anchorEl={scoreEl}
+        open={ratingOpen}
+        onClose={() => setRatingOpen(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Box sx={{ width: 200, pt: 2, px: 2, pb: 0.5 }} onClick={(e) => e.stopPropagation()}>
@@ -252,7 +263,7 @@ export const BookCoverCard = ({
                 const next = Math.max(1, Math.round((value ?? 0) * 2))
                 setRatingDraft(next)
                 onRatingChange?.(next)
-                setRatingAnchor(null)
+                setRatingOpen(false)
               }}
             />
           </Box>
@@ -264,7 +275,7 @@ export const BookCoverCard = ({
             onChange={(_, value) => setRatingDraft(value as number)}
             onChangeCommitted={(_, value) => {
               onRatingChange?.(value as number)
-              setRatingAnchor(null)
+              setRatingOpen(false)
             }}
           />
           <Typography align="center" sx={{ fontWeight: 600, mb: 0.5 }}>

--- a/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.module.scss
+++ b/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.module.scss
@@ -154,6 +154,10 @@
   cursor: pointer;
 }
 
+.table-row__rating--disabled {
+  cursor: default;
+}
+
 .table-row__rating-value {
   font-size: 13px;
   font-weight: 600;

--- a/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.tsx
+++ b/apps/web/src/entities/book/ui/BookTableRow/BookTableRow.tsx
@@ -66,8 +66,16 @@ export const BookTableRow = ({
   onRatingChange,
 }: BookTableRowProps) => {
   const { book, status, rating } = entry
-  const [statusAnchor, setStatusAnchor] = useState<HTMLElement | null>(null)
-  const [ratingAnchor, setRatingAnchor] = useState<HTMLElement | null>(null)
+  // anchorEl держим в state, обновляемом через callback ref, а не как
+  // ссылку, замороженную в момент клика: если фоновая перезагрузка списка
+  // (после мутации статуса/оценки) пересоздаст DOM-узел строки, пока
+  // поп-овер ещё открыт, React сам вызовет callback ref на новом узле —
+  // и anchorEl останется верным. Замороженная на клике ссылка вместо этого
+  // указывала бы в никуда, и MUI Popover схлопывал позицию в (0,0).
+  const [statusEl, setStatusEl] = useState<HTMLSpanElement | null>(null)
+  const [ratingEl, setRatingEl] = useState<HTMLDivElement | null>(null)
+  const [statusOpen, setStatusOpen] = useState(false)
+  const [ratingOpen, setRatingOpen] = useState(false)
   // Черновое значение слайдера — обновляется при перетаскивании,
   // а мутация отправляется только когда пользователь отпускает слайдер.
   const [ratingDraft, setRatingDraft] = useState(rating ?? 5)
@@ -75,21 +83,21 @@ export const BookTableRow = ({
   /** Открывает поп-овер выбора статуса, не давая клику дойти до редактирования строки. */
   const handleStatusClick = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation()
-    setStatusAnchor(e.currentTarget)
+    setStatusOpen(true)
   }
 
   /** Открывает поп-овер выбора оценки, не давая клику дойти до редактирования строки. */
   const handleRatingClick = (e: MouseEvent<HTMLElement>) => {
     e.stopPropagation()
     setRatingDraft(rating ?? 5)
-    setRatingAnchor(e.currentTarget)
+    setRatingOpen(true)
   }
 
   return (
     <div className={styles['table-row']}>
       <div className={styles['table-row__cover-wrap']} onClick={onEdit}>
         <div className={styles['table-row__cover']} />
-        {rating === 10 && <div className={styles['table-row__gold-ring']} />}
+        {status === 'DONE' && rating === 10 && <div className={styles['table-row__gold-ring']} />}
       </div>
 
       <div className={styles['table-row__info']} onClick={onEdit}>
@@ -98,6 +106,7 @@ export const BookTableRow = ({
       </div>
 
       <span
+        ref={setStatusEl}
         className={`${styles['table-row__status']} ${STATUS_CLASS[status]}`}
         onClick={handleStatusClick}
       >
@@ -105,10 +114,12 @@ export const BookTableRow = ({
         {STATUS_LABEL[status]}
       </span>
 
-      <div className={styles['table-row__rating']} onClick={handleRatingClick}>
-        {rating === null ? (
-          <span className={styles['table-row__rating-empty']}>—</span>
-        ) : (
+      <div
+        ref={setRatingEl}
+        className={`${styles['table-row__rating']} ${status !== 'DONE' ? styles['table-row__rating--disabled'] : ''}`}
+        onClick={status === 'DONE' ? handleRatingClick : undefined}
+      >
+        {status === 'DONE' && rating !== null ? (
           <>
             <Rating
               readOnly
@@ -127,13 +138,15 @@ export const BookTableRow = ({
               {rating === 10 ? <Star size={13} fill={GOLD_COLOR} stroke="none" /> : rating}
             </span>
           </>
+        ) : (
+          <span className={styles['table-row__rating-empty']}>—</span>
         )}
       </div>
 
       <Menu
-        anchorEl={statusAnchor}
-        open={!!statusAnchor}
-        onClose={() => setStatusAnchor(null)}
+        anchorEl={statusEl}
+        open={statusOpen}
+        onClose={() => setStatusOpen(false)}
         slotProps={{ list: { dense: true } }}
       >
         {STATUS_OPTIONS.map((option) => (
@@ -144,7 +157,7 @@ export const BookTableRow = ({
             onClick={(e) => {
               e.stopPropagation()
               onStatusChange?.(option.value)
-              setStatusAnchor(null)
+              setStatusOpen(false)
             }}
           >
             <Box
@@ -163,9 +176,9 @@ export const BookTableRow = ({
       </Menu>
 
       <Popover
-        anchorEl={ratingAnchor}
-        open={!!ratingAnchor}
-        onClose={() => setRatingAnchor(null)}
+        anchorEl={ratingEl}
+        open={ratingOpen}
+        onClose={() => setRatingOpen(false)}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >
         <Box sx={{ width: 200, pt: 2, px: 2, pb: 0.5 }} onClick={(e) => e.stopPropagation()}>
@@ -183,7 +196,7 @@ export const BookTableRow = ({
                 const next = Math.max(1, Math.round((value ?? 0) * 2))
                 setRatingDraft(next)
                 onRatingChange?.(next)
-                setRatingAnchor(null)
+                setRatingOpen(false)
               }}
             />
           </Box>
@@ -195,7 +208,7 @@ export const BookTableRow = ({
             onChange={(_, value) => setRatingDraft(value as number)}
             onChangeCommitted={(_, value) => {
               onRatingChange?.(value as number)
-              setRatingAnchor(null)
+              setRatingOpen(false)
             }}
           />
           <Typography align="center" sx={{ fontWeight: 600, mb: 0.5 }}>

--- a/apps/web/src/features/book/api/booksApi.ts
+++ b/apps/web/src/features/book/api/booksApi.ts
@@ -111,6 +111,23 @@ export const booksApi = baseApi.injectEndpoints({
     updateEntry: build.mutation<BookEntry, { id: string; dto: UpdateBookEntryDto }>({
       query: ({ id, dto }) => ({ url: `/books/entries/${id}`, method: 'PATCH', body: dto }),
       invalidatesTags: ['Book'],
+      // Меняем запись в кэше сразу, не дожидаясь ответа сервера — иначе при
+      // медленном ответе элементы интерфейса (например поп-овер оценки на
+      // карточке) остаются в состоянии ожидания и могут вести себя не так,
+      // как ожидается. Если запрос всё же завершится ошибкой — откатываем.
+      async onQueryStarted({ id, dto }, { dispatch, queryFulfilled }) {
+        const patchResult = dispatch(
+          booksApi.util.updateQueryData('getMyEntries', undefined, (draft) => {
+            const entry = draft.find((e) => e.id === id)
+            if (entry) Object.assign(entry, dto)
+          }),
+        )
+        try {
+          await queryFulfilled
+        } catch {
+          patchResult.undo()
+        }
+      },
     }),
 
     /**


### PR DESCRIPTION
## Changes
- Rating badge on book cards (cover and table view) is now hidden unless the entry's status is "done", matching the edit form's behavior — previously it was always shown and editable regardless of status.
- Status/rating popover used to anchor to a DOM node frozen in component state at click time. If the entries list refetched in the background while the popover was open (e.g. after a slow mutation response), the node could be replaced and the popover would snap to the top-left corner of the app. Switched to a callback ref so the anchor always tracks the live node.
- Rating/status updates now apply optimistically to the cache, so the UI updates instantly instead of waiting on the server response.