### PR TITLE
feat(web): integrate zod validation in book modal forms

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@hookform/resolvers": "^5.4.0",
     "@mui/icons-material": "^9.0.0",
     "@mui/material": "^9.0.0",
     "@reduxjs/toolkit": "^2.11.2",
@@ -26,7 +27,8 @@
     "react-dom": "^19.1.0",
     "react-hook-form": "^7.79.0",
     "react-redux": "^9.2.0",
-    "react-router": "^7.14.2"
+    "react-router": "^7.14.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/apps/web/src/entities/book/ui/BookExpandModal/BookCreateForm.tsx
+++ b/apps/web/src/entities/book/ui/BookExpandModal/BookCreateForm.tsx
@@ -1,33 +1,13 @@
 import { useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { motion } from 'framer-motion'
 import { X } from 'lucide-react'
 import { STATUS_OPTIONS, STATUS_TEXT_COLOR } from '../../model/book.types'
-import type { BookStatus } from '../../model/book.types'
 import type { CreateBookPayload } from './BookExpandModal.types'
+import { createBookSchema } from './bookFormSchemas'
+import type { CreateFormValues } from './bookFormSchemas'
 import styles from './BookExpandModal.module.scss'
-
-/**
- * Значения формы создания книги.
- */
-interface CreateFormValues {
-  /** Название книги. */
-  title: string
-  /** Автор книги. */
-  author: string
-  /** Количество страниц (строка, конвертируется при отправке). */
-  pageCount: string
-  /** Описание книги. */
-  description: string
-  /** Статус чтения. */
-  status: BookStatus
-  /** Оценка (1–10). */
-  rating: number
-  /** Прочитано страниц. */
-  progress: number
-  /** Заметки пользователя. */
-  notes: string
-}
 
 /**
  * Пропсы BookCreateForm.
@@ -53,8 +33,9 @@ export const BookCreateForm = ({ isMobile, onCreate, onClose }: BookCreateFormPr
     handleSubmit,
     setValue,
     control,
-    formState: { isSubmitting },
+    formState: { isSubmitting, errors },
   } = useForm<CreateFormValues>({
+    resolver: zodResolver(createBookSchema),
     defaultValues: {
       title: '',
       author: '',
@@ -126,6 +107,7 @@ export const BookCreateForm = ({ isMobile, onCreate, onClose }: BookCreateFormPr
                 placeholder="Введите название"
                 {...register('title')}
               />
+              {errors.title && <p className={styles['em__error']}>{errors.title.message}</p>}
             </div>
 
             <div className={styles['em__field']}>

--- a/apps/web/src/entities/book/ui/BookExpandModal/BookEntryView.tsx
+++ b/apps/web/src/entities/book/ui/BookExpandModal/BookEntryView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useForm, useWatch } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { motion } from 'framer-motion'
 import { Check, Pencil, Star, Trash2, X } from 'lucide-react'
 import {
@@ -20,27 +21,9 @@ import {
 import type { BookEntry, BookStatus } from '../../model/book.types'
 import { ScoreBadge } from '../ScoreBadge/ScoreBadge'
 import type { BookFieldUpdate, EntryFieldUpdate } from './BookExpandModal.types'
+import { editBookSchema } from './bookFormSchemas'
+import type { EditFormValues } from './bookFormSchemas'
 import styles from './BookExpandModal.module.scss'
-
-/**
- * Значения формы редактирования записи.
- */
-interface EditFormValues {
-  /** Название книги. */
-  title: string
-  /** Автор книги. */
-  author: string
-  /** Количество страниц (строка, конвертируется при отправке). */
-  pageCount: string
-  /** Описание книги. */
-  description: string
-  /** Заметки пользователя. */
-  notes: string
-  /** Оценка (1–10). */
-  rating: number
-  /** Прочитано страниц. */
-  progress: number
-}
 
 /**
  * Пропсы BookEntryView.
@@ -110,8 +93,9 @@ export const BookEntryView = ({
     handleSubmit,
     reset,
     control,
-    formState: { isSubmitting, dirtyFields },
+    formState: { isSubmitting, dirtyFields, errors },
   } = useForm<EditFormValues>({
+    resolver: zodResolver(editBookSchema),
     defaultValues: {
       title: entry.book.title,
       author: entry.book.author,
@@ -227,6 +211,7 @@ export const BookEntryView = ({
                     autoFocus
                     {...register('title')}
                   />
+                  {errors.title && <p className={styles['em__error']}>{errors.title.message}</p>}
                 </div>
 
                 <div className={styles['em__field']}>

--- a/apps/web/src/entities/book/ui/BookExpandModal/bookFormSchemas.ts
+++ b/apps/web/src/entities/book/ui/BookExpandModal/bookFormSchemas.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+// Допустимые значения статуса книги.
+const BOOK_STATUS_VALUES = ['WANT', 'READING', 'DROPPED', 'DONE'] as const
+
+/**
+ * Схема валидации формы создания книги.
+ */
+export const createBookSchema = z.object({
+  title: z.string().min(1, 'Введите название'),
+  author: z.string(),
+  pageCount: z.string(),
+  description: z.string(),
+  status: z.enum(BOOK_STATUS_VALUES),
+  rating: z.number().min(1).max(10),
+  progress: z.number().min(0),
+  notes: z.string(),
+})
+
+/**
+ * Значения формы создания книги.
+ */
+export type CreateFormValues = z.infer<typeof createBookSchema>
+
+/**
+ * Схема валидации формы редактирования записи.
+ */
+export const editBookSchema = z.object({
+  title: z.string().min(1, 'Введите название'),
+  author: z.string(),
+  pageCount: z.string(),
+  description: z.string(),
+  notes: z.string(),
+  rating: z.number().min(1).max(10),
+  progress: z.number().min(0),
+})
+
+/**
+ * Значения формы редактирования записи.
+ */
+export type EditFormValues = z.infer<typeof editBookSchema>

--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@hookform/resolvers": "^5.4.0",
         "@mui/icons-material": "^9.0.0",
         "@mui/material": "^9.0.0",
         "@reduxjs/toolkit": "^2.11.2",
@@ -153,7 +154,8 @@
         "react-dom": "^19.1.0",
         "react-hook-form": "^7.79.0",
         "react-redux": "^9.2.0",
-        "react-router": "^7.14.2"
+        "react-router": "^7.14.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -2338,6 +2340,18 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -17779,10 +17793,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary
- Added `zod` and `@hookform/resolvers` as explicit dependencies in `apps/web`
- Created `bookFormSchemas.ts` with `createBookSchema` and `editBookSchema` — single source of truth for form structure and validation rules
- Replaced manual `interface` form types with `z.infer<typeof schema>` in `BookCreateForm` and `BookEntryView`
- Wired `zodResolver` into `useForm` in both components
- Added inline validation error display under the title field in both forms

Closes #176