### PR TITLE
feat(web): add skeleton loading state to library page

### DIFF
--- a/apps/web/src/entities/book/index.ts
+++ b/apps/web/src/entities/book/index.ts
@@ -1,4 +1,5 @@
 export { BookCoverCard } from './ui/BookCoverCard/BookCoverCard'
+export { BookCoverCardSkeleton } from './ui/BookCoverCardSkeleton/BookCoverCardSkeleton'
 export { BookTableRow } from './ui/BookTableRow/BookTableRow'
 export { BookExpandModal } from './ui/BookExpandModal/BookExpandModal'
 export type {

--- a/apps/web/src/entities/book/ui/BookCoverCardSkeleton/BookCoverCardSkeleton.module.scss
+++ b/apps/web/src/entities/book/ui/BookCoverCardSkeleton/BookCoverCardSkeleton.module.scss
@@ -1,0 +1,10 @@
+.card-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+
+  &--compact {
+    gap: 7px;
+  }
+}

--- a/apps/web/src/entities/book/ui/BookCoverCardSkeleton/BookCoverCardSkeleton.tsx
+++ b/apps/web/src/entities/book/ui/BookCoverCardSkeleton/BookCoverCardSkeleton.tsx
@@ -1,0 +1,26 @@
+import Skeleton from '@mui/material/Skeleton'
+import styles from './BookCoverCardSkeleton.module.scss'
+
+/** Размер карточки-скелетона — совпадает с размером BookCoverCard. */
+type CardSize = 'compact' | 'medium' | 'large'
+
+/**
+ * Свойства BookCoverCardSkeleton.
+ */
+interface BookCoverCardSkeletonProps {
+  /** Размер карточки. По умолчанию «large». */
+  size?: CardSize
+}
+
+/**
+ * Скелетон карточки книги в стиле «обложка» — повторяет форму BookCoverCard.
+ */
+export const BookCoverCardSkeleton = ({ size = 'large' }: BookCoverCardSkeletonProps) => (
+  <div className={`${styles['card-skeleton']} ${styles[`card-skeleton--${size}`] ?? ''}`}>
+    <Skeleton
+      variant="rounded"
+      sx={{ width: '100%', aspectRatio: '2/3', height: 'auto', borderRadius: '10px' }}
+    />
+    <Skeleton variant="rounded" width={72} height={22} sx={{ borderRadius: '999px' }} />
+  </div>
+)

--- a/apps/web/src/pages/library/LibraryPage.tsx
+++ b/apps/web/src/pages/library/LibraryPage.tsx
@@ -24,11 +24,18 @@ import {
   Box,
   Menu,
   MenuItem,
+  Skeleton,
   Tooltip,
   useMediaQuery,
   useTheme,
 } from '@mui/material'
-import { BookCoverCard, BookExpandModal, BookTableRow, STATUS_LABEL } from '@/entities/book'
+import {
+  BookCoverCard,
+  BookCoverCardSkeleton,
+  BookExpandModal,
+  BookTableRow,
+  STATUS_LABEL,
+} from '@/entities/book'
 import type {
   BookEntry,
   BookFieldUpdate,
@@ -221,7 +228,58 @@ export const LibraryPage = () => {
     await deleteEntry(expandedEntry.id).unwrap()
   }
 
-  if (isLoading) return null
+  if (isLoading) {
+    return (
+      <div className={styles.library} style={{ height: '100%' }}>
+        <div className={styles['library__header']}>
+          <h1 className={styles['library__title']}>Моя библиотека</h1>
+          <button className={styles['library__add-btn']} onClick={handleAddClick}>
+            <Plus size={16} />
+            <span className={styles['library__add-btn-label']}>Добавить книгу</span>
+          </button>
+        </div>
+
+        {!isMobile && (
+          <div className={styles['library__tabs']}>
+            {[56, 110, 80, 95, 75].map((w, i) => (
+              <Skeleton
+                key={i}
+                variant="rounded"
+                width={w}
+                height={34}
+                sx={{ borderRadius: '999px' }}
+              />
+            ))}
+          </div>
+        )}
+
+        <div className={styles['library__label-row']}>
+          <Skeleton
+            variant="rounded"
+            sx={{ flex: 1, maxWidth: 480, height: 36, borderRadius: '10px' }}
+          />
+          <div className={styles['library__label-row-actions']}>
+            <Skeleton variant="rounded" width={110} height={36} sx={{ borderRadius: '10px' }} />
+            {!isMobile && (
+              <>
+                <Skeleton variant="rounded" width={110} height={36} sx={{ borderRadius: '10px' }} />
+                <Skeleton variant="rounded" width={72} height={40} sx={{ borderRadius: '11px' }} />
+              </>
+            )}
+          </div>
+        </div>
+
+        <div
+          className={`${styles['library__grid']} ${styles[`library__grid--${effectiveCardSize}`] ?? ''}`}
+          style={{ flex: 1, overflow: 'hidden', minHeight: 0 }}
+        >
+          {Array.from({ length: 24 }).map((_, i) => (
+            <BookCoverCardSkeleton key={i} size={effectiveCardSize} />
+          ))}
+        </div>
+      </div>
+    )
+  }
 
   return (
     <LayoutGroup id="library">


### PR DESCRIPTION
## Summary
- Added `BookCoverCardSkeleton` component — mimics the shape of `BookCoverCard` using MUI `Skeleton` with shimmer animation; supports all three card sizes (compact / medium / large)
- Replaced `return null` during loading with a full skeleton layout: header + add button render immediately, status tabs and search row are shown as skeletons, card grid is filled with 24 skeleton cards clipped at the bottom edge (no scroll)
- Skeleton grid uses `flex: 1; overflow: hidden` so cards fill the viewport and are clipped at the bottom without triggering a scrollbar
- Card size for skeletons is derived from `localStorage` (same as the real grid), so the skeleton matches the user's preferred layout on desktop; on mobile always uses `large`

Closes #178