### PR TITLE
fix(web): guard matchmedia call for non-browser environments

### DIFF
--- a/apps/web/src/features/theme/model/themeSlice.ts
+++ b/apps/web/src/features/theme/model/themeSlice.ts
@@ -29,7 +29,9 @@ function loadState(): ThemeState {
     lightVariant: DEFAULT_THEME,
     darkVariant: defaultDark,
     themeMode: 'system',
-    isDark: window.matchMedia('(prefers-color-scheme: dark)').matches,
+    isDark:
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches,
     isCustomPair: false,
   }
   try {


### PR DESCRIPTION
## Summary
- Added `typeof window.matchMedia === 'function'` guard before calling the API
- Fixes test failures in jsdom environment where `matchMedia` is not implemented

Closes #184