### PR TITLE
feat(web): migrate navigation to i18n (sidebar, mobile nav)

### DIFF
--- a/apps/web/src/shared/locales/en.json
+++ b/apps/web/src/shared/locales/en.json
@@ -38,5 +38,17 @@
         }
       }
     }
+  },
+  "nav": {
+    "home": "Home",
+    "profile": "Profile",
+    "library": "Library",
+    "feed": "Feed",
+    "friends": "Friends",
+    "search": "Search",
+    "settings": "Settings",
+    "comingSoon": "Coming soon",
+    "lightTheme": "Light theme",
+    "darkTheme": "Dark theme"
   }
 }

--- a/apps/web/src/shared/locales/ru.json
+++ b/apps/web/src/shared/locales/ru.json
@@ -38,5 +38,17 @@
         }
       }
     }
+  },
+  "nav": {
+    "home": "Главная",
+    "profile": "Профиль",
+    "library": "Библиотека",
+    "feed": "Лента",
+    "friends": "Друзья",
+    "search": "Поиск",
+    "settings": "Настройки",
+    "comingSoon": "Скоро",
+    "lightTheme": "Светлая тема",
+    "darkTheme": "Тёмная тема"
   }
 }

--- a/apps/web/src/widgets/layout/MobileNav.tsx
+++ b/apps/web/src/widgets/layout/MobileNav.tsx
@@ -6,23 +6,25 @@ import RssFeedOutlinedIcon from '@mui/icons-material/RssFeedOutlined'
 import SearchOutlinedIcon from '@mui/icons-material/SearchOutlined'
 import { useNavigate, useLocation } from 'react-router'
 import type { SvgIconComponent } from '@mui/icons-material'
+import { useTranslation } from 'react-i18next'
 import styles from './MobileNav.module.scss'
 
-/** Раздел еще не реализован — пункт виден, но недоступен для перехода. */
-const NAV_ITEMS: { to: string; icon: SvgIconComponent; label: string; disabled?: boolean }[] = [
-  { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
-  { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
-  { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
-  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента', disabled: true },
-  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск', disabled: true },
-]
-
 /**
- * Нижняя навигация для мобильных устройств
+ * Нижняя навигация для мобильных устройств.
  */
 export const MobileNav = () => {
+  const { t } = useTranslation()
   const navigate = useNavigate()
   const { pathname } = useLocation()
+
+  /** Конфигурация пункта нижней навигации. */
+  const navItems: { to: string; icon: SvgIconComponent; label: string; disabled?: boolean }[] = [
+    { to: '/', icon: HomeOutlinedIcon, label: t('nav.home') },
+    { to: '/profile', icon: AccountCircleOutlinedIcon, label: t('nav.profile') },
+    { to: '/library', icon: AutoStoriesOutlinedIcon, label: t('nav.library') },
+    { to: '/feed', icon: RssFeedOutlinedIcon, label: t('nav.feed'), disabled: true },
+    { to: '/search', icon: SearchOutlinedIcon, label: t('nav.search'), disabled: true },
+  ]
 
   return (
     <Paper
@@ -32,7 +34,7 @@ export const MobileNav = () => {
       sx={{ zIndex: (theme) => theme.zIndex.appBar }}
     >
       <Box className={styles['mobile-nav__items']}>
-        {NAV_ITEMS.map(({ to, icon: Icon, label, disabled }) => {
+        {navItems.map(({ to, icon: Icon, label, disabled }) => {
           // Для "/" нужно точное совпадение, иначе будет активен на всех страницах
           const isActive = !disabled && (to === '/' ? pathname === '/' : pathname.startsWith(to))
           return (

--- a/apps/web/src/widgets/layout/Sidebar.tsx
+++ b/apps/web/src/widgets/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import type { SvgIconComponent } from '@mui/icons-material'
 import { Tooltip } from '@mui/material'
 import { Moon, Sun } from 'lucide-react'
 import { Link, useMatch } from 'react-router'
+import { useTranslation } from 'react-i18next'
 import { useAppDispatch, useAppSelector } from '@/shared/lib/store'
 import { toggleDark } from '@/features/theme'
 import styles from './Sidebar.module.scss'
@@ -19,36 +20,31 @@ import styles from './Sidebar.module.scss'
  * Конфигурация пункта навигации.
  */
 interface NavItemConfig {
+  /** Путь маршрута. */
   to: string
+  /** Иконка пункта. */
   icon: SvgIconComponent
+  /** Метка пункта. */
   label: string
-  /** Раздел еще не реализован — пункт виден, но недоступен для перехода. */
+  /** Флаг недоступности — пункт виден, но не кликабелен. */
   disabled?: boolean
 }
 
-const NAV_ITEMS: NavItemConfig[] = [
-  { to: '/', icon: HomeOutlinedIcon, label: 'Главная' },
-  { to: '/profile', icon: AccountCircleOutlinedIcon, label: 'Профиль' },
-  { to: '/library', icon: AutoStoriesOutlinedIcon, label: 'Библиотека' },
-  { to: '/feed', icon: RssFeedOutlinedIcon, label: 'Лента', disabled: true },
-  { to: '/friends', icon: PeopleOutlinedIcon, label: 'Друзья', disabled: true },
-  { to: '/search', icon: SearchOutlinedIcon, label: 'Поиск', disabled: true },
-]
-
-const FOOTER_ITEMS: NavItemConfig[] = [
-  { to: '/settings', icon: SettingsOutlinedIcon, label: 'Настройки' },
-]
-
+/**
+ * Свойства NavItem.
+ */
 interface NavItemProps extends NavItemConfig {
+  /** Флаг свёрнутого состояния сайдбара. */
   collapsed: boolean
 }
 
 const NavItem = ({ to, icon: Icon, label, collapsed, disabled }: NavItemProps) => {
+  const { t } = useTranslation()
   const isActive = !!useMatch({ path: to, end: to === '/' })
 
   if (disabled) {
     return (
-      <Tooltip title="Скоро" placement="right">
+      <Tooltip title={t('nav.comingSoon')} placement="right">
         <span
           className={`${styles['nav-item']} ${styles['nav-item--disabled']} ${collapsed ? styles['nav-item--collapsed'] : ''}`}
         >
@@ -74,7 +70,9 @@ const NavItem = ({ to, icon: Icon, label, collapsed, disabled }: NavItemProps) =
  * Свойства сайдбара.
  */
 interface Props {
+  /** Флаг свёрнутого состояния. */
   collapsed: boolean
+  /** Функция переключения состояния. */
   onToggle: () => void
 }
 
@@ -82,8 +80,24 @@ interface Props {
  * Боковое меню приложения.
  */
 export const Sidebar = ({ collapsed, onToggle }: Props) => {
+  const { t } = useTranslation()
   const dispatch = useAppDispatch()
   const isDark = useAppSelector((s) => s.theme.isDark)
+
+  const navItems: NavItemConfig[] = [
+    { to: '/', icon: HomeOutlinedIcon, label: t('nav.home') },
+    { to: '/profile', icon: AccountCircleOutlinedIcon, label: t('nav.profile') },
+    { to: '/library', icon: AutoStoriesOutlinedIcon, label: t('nav.library') },
+    { to: '/feed', icon: RssFeedOutlinedIcon, label: t('nav.feed'), disabled: true },
+    { to: '/friends', icon: PeopleOutlinedIcon, label: t('nav.friends'), disabled: true },
+    { to: '/search', icon: SearchOutlinedIcon, label: t('nav.search'), disabled: true },
+  ]
+
+  const footerItems: NavItemConfig[] = [
+    { to: '/settings', icon: SettingsOutlinedIcon, label: t('nav.settings') },
+  ]
+
+  const themeLabel = isDark ? t('nav.lightTheme') : t('nav.darkTheme')
 
   return (
     <div className={styles['sidebar']}>
@@ -106,27 +120,23 @@ export const Sidebar = ({ collapsed, onToggle }: Props) => {
       </div>
 
       <nav className={styles['sidebar__nav']}>
-        {NAV_ITEMS.map((item) => (
+        {navItems.map((item) => (
           <NavItem key={item.to} {...item} collapsed={collapsed} />
         ))}
       </nav>
 
       <div className={styles['sidebar__footer']}>
-        <Tooltip title={isDark ? 'Светлая тема' : 'Тёмная тема'} placement="right">
+        <Tooltip title={themeLabel} placement="right">
           <button
             className={`${styles['theme-toggle']} ${collapsed ? styles['theme-toggle--collapsed'] : ''}`}
             onClick={() => dispatch(toggleDark())}
           >
             {isDark ? <Sun size={22} /> : <Moon size={22} />}
-            {!collapsed && (
-              <span className={styles['theme-toggle__label']}>
-                {isDark ? 'Светлая тема' : 'Тёмная тема'}
-              </span>
-            )}
+            {!collapsed && <span className={styles['theme-toggle__label']}>{themeLabel}</span>}
           </button>
         </Tooltip>
 
-        {FOOTER_ITEMS.map((item) => (
+        {footerItems.map((item) => (
           <NavItem key={item.to} {...item} collapsed={collapsed} />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- Migrated `Sidebar` and `MobileNav` to react-i18next
- Added `nav.*` keys to `ru.json` and `en.json`

## Changes
- `widgets/layout/Sidebar.tsx` — nav items and theme toggle label use `t()`
- `widgets/layout/MobileNav.tsx` — nav items use `t()`
- `shared/locales/ru.json` — added `nav` section (10 keys)
- `shared/locales/en.json` — added `nav` section (10 keys)

## Test plan
- [ ] `check:i18n` passes — all ru keys present in en
- [ ] All tests pass
- [ ] Nav labels visible in both languages via `localStorage.setItem('treqio_lang', 'en')`

Closes #192