### PR TITLE
feat(web): add typescript type safety for i18n keys

### DIFF
--- a/apps/web/src/shared/lib/i18next.d.ts
+++ b/apps/web/src/shared/lib/i18next.d.ts
@@ -1,0 +1,8 @@
+import type ru from '../locales/ru.json'
+
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    defaultNS: 'translation'
+    resources: { translation: typeof ru }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `shared/lib/i18next.d.ts` — module augmentation for i18next `CustomTypeOptions`
- Typos in `t()` keys now produce TypeScript errors in the editor
- Full autocomplete for all translation keys

## Details
The file augments i18next with the shape of `ru.json`, which is the source of truth for all keys (enforced by `check:i18n` pre-push hook).

Note: named `i18next.d.ts` (not `i18n.d.ts`) to avoid TypeScript treating it as a declaration file for `i18n.ts`.

Closes #195